### PR TITLE
fix: remove duplicate hooks declaration and align hook JSON schemas

### DIFF
--- a/plugins/hawkscan/.claude-plugin/plugin.json
+++ b/plugins/hawkscan/.claude-plugin/plugin.json
@@ -10,6 +10,5 @@
   "homepage": "https://docs.stackhawk.com",
   "repository": "https://github.com/stackhawk/agent-skills",
   "license": "MIT",
-  "keywords": ["security", "dast", "appsec", "hawkscan", "stackhawk", "api-security", "vulnerability-scanning"],
-  "hooks": "./hooks/hooks.json"
+  "keywords": ["security", "dast", "appsec", "hawkscan", "stackhawk", "api-security", "vulnerability-scanning"]
 }

--- a/plugins/hawkscan/.codex-plugin/plugin.json
+++ b/plugins/hawkscan/.codex-plugin/plugin.json
@@ -11,6 +11,5 @@
   "repository": "https://github.com/stackhawk/agent-skills",
   "license": "MIT",
   "keywords": ["security", "dast", "appsec", "hawkscan", "stackhawk", "api-security", "vulnerability-scanning"],
-  "skills": "./skills/",
-  "hooks": "./hooks/hooks.json"
+  "skills": "./skills/"
 }


### PR DESCRIPTION
## Summary

- Remove `"hooks": "./hooks/hooks.json"` from both Claude and Codex `plugin.json` manifests — Claude Code auto-discovers hooks, explicit declaration causes duplicate load error
- Fix Stop hook: use `stopReason` field instead of invalid `additional_context` + `hookSpecificOutput` (Stop hooks have no hookSpecificOutput schema)
- Fix SessionStart hook: remove invalid `additional_context` top-level field, keep `hookSpecificOutput` with `additionalContext`
- Fix PostToolUse hook: remove invalid `additional_context` top-level field, keep `hookSpecificOutput` with `additionalContext`

## Test plan

- [ ] `claude /plugins` shows hawkscan with no errors
- [ ] SessionStart hook fires and injects context on session startup
- [ ] PostToolUse hook fires after `git commit` with commit SHA
- [ ] Stop hook shows reminder (via `stopReason`) when code modified without scan
- [ ] No JSON validation errors on any hook