### PR TITLE
feat: add opencode plugin discovery support

### DIFF
--- a/.opencode/skills/api
+++ b/.opencode/skills/api
@@ -1,0 +1,1 @@
+../../plugins/api/skills/api

--- a/.opencode/skills/hawkscan
+++ b/.opencode/skills/hawkscan
@@ -1,0 +1,1 @@
+../../plugins/hawkscan/skills/hawkscan

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Multi-platform agent skills repo serving Claude, Codex, Gemini, Copilot, and Cur
 - `plugins/hawkscan/` — HawkScan DAST scanning skill (SKILL.md + references)
 - `plugins/api/` — StackHawk API reporting skill (SKILL.md + references)
 - `skills/` — Symlinks for Gemini/Copilot discovery (points into plugins/)
+- `.opencode/skills/` — Symlinks for OpenCode discovery (points into plugins/)
 - `cursor/` — Generated Cursor .mdc rules (do NOT edit manually)
 - `scripts/generate-cursor-rules.sh` — Transforms SKILL.md → Cursor .mdc format
 
@@ -35,6 +36,6 @@ All platform manifests share the version in `VERSION` (currently 1.0.0).
 ## Gotchas
 
 - `cursor/` is generated output — edit the source SKILL.md, then regenerate
-- `skills/` entries are symlinks, not copies — don't break the relative paths
+- `skills/` and `.opencode/skills/` entries are symlinks, not copies — don't break the relative paths
 - `docs/superpowers/` is gitignored (design specs/plans kept locally)
 - `.claude/` dir is gitignored (local settings only)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 StackHawk agent skills teach your AI coding agent to find security vulnerabilities as you build, report your security posture across applications, and help you fix what it finds — all without leaving your workflow. No context switching, no tickets to another team. Your agent scans, reports, and remediates.
 
-Works with **Claude Code**, **Codex**, **Gemini CLI**, **GitHub Copilot**, **Cursor**, and anywhere the [Agent Skills standard](https://agentskills.io) is supported.
+Works with **Claude Code**, **Codex**, **Gemini CLI**, **GitHub Copilot**, **OpenCode**, **Cursor**, and anywhere the [Agent Skills standard](https://agentskills.io) is supported.
 
 ---
 
@@ -76,6 +76,22 @@ mkdir -p .agents/skills
 cp -r path/to/stackhawk-agent-skills/skills/* .agents/skills/
 
 # Option B: If you have the Claude plugin installed, Copilot reads .claude/skills/ automatically
+```
+
+#### OpenCode
+
+Skills are auto-discovered from `.opencode/skills/`, `.claude/skills/`, or `.agents/skills/`. Add to your project or user config:
+
+```bash
+# Per-project: copy into your project's .opencode/skills/
+mkdir -p .opencode/skills
+cp -r path/to/stackhawk-agent-skills/.opencode/skills/* .opencode/skills/
+
+# Global: install for all projects
+mkdir -p ~/.config/opencode/skills
+cp -r path/to/stackhawk-agent-skills/.opencode/skills/* ~/.config/opencode/skills/
+
+# If the Claude plugin is already installed, opencode reads .claude/skills/ automatically
 ```
 
 #### Cursor
@@ -165,6 +181,7 @@ cursor/                          Generated Cursor .mdc rules
 | Codex | `/plugin install` | Agent Skills standard (SKILL.md) |
 | Gemini CLI | `gemini extensions install` | Agent Skills standard (SKILL.md) |
 | GitHub Copilot | Copy to `.agents/skills/` | Agent Skills standard (SKILL.md) |
+| OpenCode | Copy to `.opencode/skills/` | Agent Skills standard (SKILL.md) |
 | Cursor | Copy `.mdc` rules | Generated from canonical source |
 
 ---


### PR DESCRIPTION
## Summary
- Add `.opencode/skills/` with symlinks to the canonical `plugins/*/skills/*` folders so OpenCode users get a native discovery path, mirroring the existing Gemini/Copilot convention.
- Document OpenCode install in README (per-project and global paths) and add a row to the Platform Support table.
- Update CLAUDE.md structure notes and symlink gotcha to cover `.opencode/skills/`.

No SKILL.md or manifest changes. OpenCode reads the existing Agent Skills frontmatter natively, so no VERSION bump and no generator changes were needed.

## Test plan
- [x] `.opencode/skills/hawkscan/SKILL.md` and `.opencode/skills/api/SKILL.md` resolve via the new symlinks
- [x] `bash scripts/generate-cursor-rules.sh` produces no diff under `cursor/` (idempotent)
- [ ] Verify opencode discovers both skills when the repo is dropped into a test project