### PR TITLE
feat(hawkscan): Phase 0 app setup, tech flags, and triage write

### DIFF
--- a/cursor/.cursor/rules/stackhawk-api-hawkop.mdc
+++ b/cursor/.cursor/rules/stackhawk-api-hawkop.mdc
@@ -14,13 +14,54 @@ See `SKILL.md` for the workflow that decides when to use `hawkop` vs raw REST.
 
 ## Setup (once)
 
+**Homebrew (macOS/Linux — recommended):**
 ```bash
-# Install (macOS / Linux)
 brew tap stackhawk/hawkop && brew install hawkop
+```
 
-# Or download signed artifacts directly from https://download.stackhawk.com/hawkop/
-# See https://docs.stackhawk.com/hawkop/#installation
+**Direct downloads:** `https://download.stackhawk.com/hawkop/`
+Downloads page: `https://docs.stackhawk.com/downloads/hawkop/`
 
+Check the current version:
+```bash
+curl -s https://download.stackhawk.com/hawkop/latest-version.txt
+```
+
+**macOS — PKG installer (universal, includes all architectures):**
+```bash
+VERSION=$(curl -s https://download.stackhawk.com/hawkop/latest-version.txt)
+curl -Lo hawkop.pkg "https://download.stackhawk.com/hawkop/pkg/hawkop-v${VERSION}-macos-universal.pkg"
+open hawkop.pkg
+```
+
+**Windows — MSI installer:**
+```powershell
+$Version = (Invoke-WebRequest https://download.stackhawk.com/hawkop/latest-version.txt).Content.Trim()
+Invoke-WebRequest "https://download.stackhawk.com/hawkop/msi/hawkop-v$Version-windows-x64.msi" -OutFile hawkop.msi
+Start-Process msiexec.exe -ArgumentList "/i hawkop.msi /passive" -Wait
+```
+
+**Linux / archive installs** (base: `https://download.stackhawk.com/hawkop/cli/`):
+
+| Platform | Filename |
+|----------|----------|
+| macOS Intel | `hawkop-v{VERSION}-x86_64-apple-darwin.tar.gz` |
+| macOS Apple Silicon | `hawkop-v{VERSION}-aarch64-apple-darwin.tar.gz` |
+| Linux x86_64 | `hawkop-v{VERSION}-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux ARM64 | `hawkop-v{VERSION}-aarch64-unknown-linux-gnu.tar.gz` |
+| Windows x86_64 | `hawkop-v{VERSION}-x86_64-pc-windows-msvc.zip` |
+
+Each archive has a matching `.sha256` checksum file at the same URL path.
+
+```bash
+# No runtime dependencies — native binary, just extract and run
+VERSION=$(curl -s https://download.stackhawk.com/hawkop/latest-version.txt)
+curl -Lo hawkop.tar.gz "https://download.stackhawk.com/hawkop/cli/hawkop-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+tar -xzf hawkop.tar.gz
+sudo mv hawkop /usr/local/bin/
+```
+
+```bash
 hawkop init            # Interactive — prompts for API key and default org
 hawkop status          # Confirm auth
 ```

--- a/cursor/.cursor/rules/stackhawk-hawkscan-false-positives.mdc
+++ b/cursor/.cursor/rules/stackhawk-hawkscan-false-positives.mdc
@@ -67,17 +67,101 @@ hawk:
 
 Use this sparingly. Prefer path exclusions over disabling entire plugins.
 
+## Triaging via the API
+
+Use `hawkop scan triage` to record false-positive decisions on the platform.
+This is the preferred action over config suppression when the finding is a true
+false positive — it creates an auditable, human-reviewable record.
+
+### When to use API triage vs. config suppression
+
+| Scenario | Action |
+|----------|--------|
+| Scanner is definitively wrong about this endpoint | **API triage** → `false-positive` with note |
+| Path should permanently be excluded from scanning | **Config** → `excludePaths` in `stackhawk.yml` |
+| Finding is noisy but not clearly wrong | **Fix it** — when in doubt, fix |
+| Both apply (wrong AND should never scan) | Do both: triage existing finding + add to `excludePaths` |
+
+### Single finding
+
+```bash
+hawkop scan triage \
+  --scan <SCAN_UUID> \
+  --hash <FINDING_HASH> \
+  --status false-positive \
+  --note "<reason — be specific: endpoint, finding name, why it's wrong>"
+```
+
+Example notes:
+- `"CSP finding on JSON endpoint /api/health which never serves HTML; header inapplicable"`
+- `"CORS wildcard on public read-only metrics API; no auth, no sensitive data"`
+- `"Rate-limit finding on /api/events; rate limiting enforced at API gateway layer"`
+
+### Bulk (multiple findings in one scan)
+
+Write a `triage.yaml`:
+```yaml
+- finding_hash: "sha256hash1"
+  status: FALSE_POSITIVE
+  note: "Health endpoint — intentional server info exposure for monitoring"
+- finding_hash: "sha256hash2"
+  status: FALSE_POSITIVE
+  note: "CORS permissive by design; public read-only API"
+```
+
+Then apply:
+```bash
+hawkop scan triage --scan <SCAN_UUID> --from-file triage.yaml
+```
+
+JSON format is also accepted (leading `[` is auto-detected). Max 100 actions per call — split into batches if needed.
+
+### Agent rules for API triage
+
+- ✅ Mark `FALSE_POSITIVE` autonomously — note must explain clearly why
+- ✅ Use `ADD_COMMENT` to annotate without changing status
+- ❌ **Never mark `RISK_ACCEPTED`** — human decision only
+- ❌ **Never mark `ASSIGNED`** — human decision only
+- ❌ Never suppress a finding by changing code to hide it from the scanner
+
+```bash
+# ADD_COMMENT example — for findings under review but not yet confirmed FP
+hawkop scan triage \
+  --scan <SCAN_UUID> \
+  --hash <FINDING_HASH> \
+  --status add-comment \
+  --note "Reviewing with team; suspected false positive on /actuator/info"
+```
+
+### How to get the finding hash
+
+The finding hash (`--hash`) comes from the scan JSON output:
+```bash
+hawk scan --json-output | jq '.findings[].hash'
+```
+
+Or from `hawkop scan get`:
+```bash
+hawkop scan get --app <APP_NAME> --detail full --format json | jq '.data.findings[].hash'
+```
+
+The scan UUID (`--scan`) comes from:
+```bash
+hawk scan --json-output | jq -r '.scan.id'
+```
+
 ## Reporting Accepted Risk
 
-When you encounter a finding that is a known false positive or accepted risk:
+When you encounter a finding that is a known false positive:
 
 1. **Do not "fix" intentional behavior.** Changing a deliberately open health endpoint
    to require auth will break monitoring.
-2. **Add the path to `excludePaths`** in `stackhawk.yml` so it doesn't trigger again.
-3. **Report it clearly:** "Finding X on path Y is an accepted risk because [reason].
-   Added to excludePaths to prevent future false positives."
-4. **If the StackHawk platform is available**, triage the finding as "Accepted Risk"
-   with a note explaining why.
+2. **Triage via the API** using `hawkop scan triage` (see section above) so the decision
+   is recorded and auditable.
+3. **Optionally add the path to `excludePaths`** in `stackhawk.yml` to prevent it from
+   appearing on future scans — useful for paths that should never be scanned.
+4. **Report it clearly:** "Finding X on path Y is a false positive because [reason].
+   Marked via API triage with note: [note]."
 
 ## When in Doubt
 

--- a/cursor/.cursor/rules/stackhawk-hawkscan-false-positives.mdc
+++ b/cursor/.cursor/rules/stackhawk-hawkscan-false-positives.mdc
@@ -35,6 +35,15 @@ scenarios:
 
 ### Exclude specific paths from scanning
 
+The scanner is pinned to the `host:` value in `stackhawk.yml` and will not
+traverse to other hosts. You do **not** need to add external domains or CDN
+URLs to `excludePaths` — the scanner won't follow them.
+
+Use `excludePaths` for same-host paths that generate noise without security
+value: static assets (images, CSS, JavaScript bundles), health endpoints,
+API docs, and similar paths that are either not user-controllable or not
+relevant to security testing.
+
 ```yaml
 app:
   excludePaths:
@@ -42,17 +51,25 @@ app:
     - /actuator/info
     - /swagger-ui
     - /api-docs
+    - /static
+    - /assets
 ```
 
-### Set failure threshold to ignore Low-severity findings
+### Control which severity triggers exit code 42
+
+`failureThreshold` belongs under `hawk:` — **never under `app:`**.
 
 ```yaml
 hawk:
-  failureThreshold: MEDIUM
+  failureThreshold: MEDIUM   # LOW | MEDIUM | HIGH
 ```
 
-This means the scan still reports Low findings but exits with code `0` instead of
-`42` — they won't trigger the fix loop.
+The scan always reports all findings regardless of this setting. `failureThreshold`
+only controls the exit code: the scan exits `42` (triggering the fix loop) when a
+finding at or above the threshold is found; otherwise it exits `0`.
+
+Use this to gate CI pipelines by severity — for example, allow Low findings to pass
+without triggering the fix loop while still recording them in the platform.
 
 ### Exclude specific scan plugins
 
@@ -78,9 +95,8 @@ false positive — it creates an auditable, human-reviewable record.
 | Scenario | Action |
 |----------|--------|
 | Scanner is definitively wrong about this endpoint | **API triage** → `false-positive` with note |
-| Path should permanently be excluded from scanning | **Config** → `excludePaths` in `stackhawk.yml` |
+| Finding is real but uncertain — needs more review | **API triage** → `add-comment` with context |
 | Finding is noisy but not clearly wrong | **Fix it** — when in doubt, fix |
-| Both apply (wrong AND should never scan) | Do both: triage existing finding + add to `excludePaths` |
 
 ### Single finding
 
@@ -89,7 +105,7 @@ hawkop scan triage \
   --scan <SCAN_UUID> \
   --hash <FINDING_HASH> \
   --status false-positive \
-  --note "<reason — be specific: endpoint, finding name, why it's wrong>"
+  --note "<reason — explain specifically why the scanner is wrong>"
 ```
 
 Example notes:
@@ -158,9 +174,7 @@ When you encounter a finding that is a known false positive:
    to require auth will break monitoring.
 2. **Triage via the API** using `hawkop scan triage` (see section above) so the decision
    is recorded and auditable.
-3. **Optionally add the path to `excludePaths`** in `stackhawk.yml` to prevent it from
-   appearing on future scans — useful for paths that should never be scanned.
-4. **Report it clearly:** "Finding X on path Y is a false positive because [reason].
+3. **Report it clearly:** "Finding X on path Y is a false positive because [reason].
    Marked via API triage with note: [note]."
 
 ## When in Doubt

--- a/cursor/.cursor/rules/stackhawk-hawkscan-install.mdc
+++ b/cursor/.cursor/rules/stackhawk-hawkscan-install.mdc
@@ -17,10 +17,39 @@ brew install hawk
 
 ### Package Installers (All Platforms)
 
-Download platform-specific installers from https://docs.stackhawk.com/downloads/:
-- **macOS:** `.pkg` installer or `.zip` (includes bundled Java)
-- **Windows:** Windows installer (includes bundled Java)
-- **Linux:** `.zip` package (may require Java 17+ installed separately)
+Downloads page: https://docs.stackhawk.com/downloads/
+
+Check the current version:
+```bash
+curl -s https://api.stackhawk.com/hawkscan/version
+# → 5.5.0
+```
+
+**macOS — PKG installer (includes bundled Java, recommended):**
+```bash
+HAWK_VERSION=$(curl -s https://api.stackhawk.com/hawkscan/version)
+curl -Lo hawk.pkg "https://download.stackhawk.com/hawk/pkg/hawk-${HAWK_VERSION}.pkg"
+sudo installer -pkg hawk.pkg -target /Applications
+```
+
+**Windows — MSI installer (includes bundled Java):**
+```powershell
+$version = Invoke-RestMethod https://api.stackhawk.com/hawkscan/version
+msiexec.exe /i "https://download.stackhawk.com/hawk/msi/hawk-${version}.msi" /passive
+```
+
+**Linux / All Platforms — ZIP (requires Java 17+ installed separately):**
+```bash
+HAWK_VERSION=$(curl -s https://api.stackhawk.com/hawkscan/version)
+curl -Lo hawk.zip "https://download.stackhawk.com/hawk/cli/hawk-${HAWK_VERSION}.zip"
+unzip hawk.zip
+echo "export PATH=\$HOME/hawk-${HAWK_VERSION}:\$PATH" >> ~/.zshrc && source ~/.zshrc
+```
+
+Direct download URL patterns (substitute version):
+- macOS PKG: `https://download.stackhawk.com/hawk/pkg/hawk-{VERSION}.pkg`
+- Windows MSI: `https://download.stackhawk.com/hawk/msi/hawk-{VERSION}.msi`
+- ZIP (all): `https://download.stackhawk.com/hawk/cli/hawk-{VERSION}.zip`
 
 ### Prerequisites
 

--- a/cursor/.cursor/rules/stackhawk-hawkscan-model.mdc
+++ b/cursor/.cursor/rules/stackhawk-hawkscan-model.mdc
@@ -132,17 +132,42 @@ on a later scan, the platform continues to report its current triage
 value (`FALSE_POSITIVE` / `RISK_ACCEPTED` stays sticky unless a human
 changes it).
 
-### The agent cannot write triage
+### What the agent can write via `hawkop scan triage`
 
-There is no API today for setting `FALSE_POSITIVE` / `RISK_ACCEPTED` /
-`ASSIGNED` programmatically. If the agent is confident a `NEW` finding is
-a true false positive, the right behavior is to **report** it in the scan
-summary with a link to `https://app.stackhawk.com/scans/<scanId>` so a
-human can triage it in the platform UI. Do NOT suppress it in the
-codebase — that would make future scans invisible.
+The `hawkop` CLI exposes triage writes. Use these in Step 4.5 of the scan
+loop when the agent identifies clear false positives.
 
-(Tracked internally as a platform-team ask; not documented in this public
-repo.)
+```bash
+# Mark a single finding path as a false positive (--note required)
+hawkop scan triage \
+  --scan <SCAN_UUID> \
+  --hash <FINDING_HASH> \
+  --status false-positive \
+  --note "CSP finding on JSON endpoint /api/health; never serves HTML"
+
+# Add a comment without changing status
+hawkop scan triage \
+  --scan <SCAN_UUID> \
+  --hash <FINDING_HASH> \
+  --status add-comment \
+  --note "Reviewed; confirmed false positive pattern"
+
+# Bulk triage from file (up to 100 actions per call)
+hawkop scan triage --scan <SCAN_UUID> --from-file triage.yaml
+```
+
+**Agent constraints:**
+- ✅ May mark `FALSE_POSITIVE` autonomously — must include a detailed `--note`
+- ✅ May use `ADD_COMMENT` to annotate findings
+- ❌ Must NOT mark `RISK_ACCEPTED` — human decision only
+- ❌ Must NOT mark `ASSIGNED` — human decision only
+- ❌ Do NOT suppress findings in code — do not change code to hide scanner results
+
+The `--note` is required for `FALSE_POSITIVE` and `ADD_COMMENT`.
+It must explain the reasoning clearly enough for a human to review and reverse if wrong.
+
+→ Bulk triage file format and false-positive heuristics:
+  [`references/false-positives.md`](false-positives.md)
 
 ### Exact JSON serialization
 
@@ -216,15 +241,27 @@ https://app.stackhawk.com/applications/<applicationId>/details/settings
 (config); tech flags tell HawkScan *which rules are relevant*. Different
 concerns.
 
-### Setting them today — no API
+### Setting tech flags via `hawkop`
 
-There is no public API for reading or writing tech flags. Setting them is
-a human action in the platform UI. This is a known platform-team gap
-tracked internally.
+Tech flags are set via the `hawkop` CLI during Phase 0 of the scan workflow
+(app onboarding). The process is: disable-all first (to clear the platform's
+all-true default), then enable only what codebase evidence supports.
 
-Until the API exists, the skill does NOT prompt users to set tech flags
-during every scan — that's noise without an API to act on. When the API
-lands, Step 1 of `SKILL.md` will gain a tech-flag reconciliation substep.
+```bash
+# 1. Fetch canonical flag list — API is source of truth for valid names
+hawkop app tech-flags get --app <APP_NAME> --format json
+
+# 2. Disable all (--yes required for non-interactive/agent use)
+hawkop app tech-flags disable-all --app <APP_NAME> --yes
+
+# 3. Enable only detected flags
+hawkop app tech-flags set --app <APP_NAME> Language.Java=true Language.Java.Spring=true
+```
+
+Phase 0 runs once at app onboarding, not on every scan.
+
+→ Full detection heuristics, matching algorithm, and edge cases:
+  [`references/tech-flags.md`](tech-flags.md)
 
 ### Detecting the right flags for a codebase
 

--- a/cursor/.cursor/rules/stackhawk-hawkscan.mdc
+++ b/cursor/.cursor/rules/stackhawk-hawkscan.mdc
@@ -21,11 +21,18 @@ coding loop. The core workflow is:
 The `api` skill wraps read-only StackHawk platform lookups via the `hawkop`
 CLI. Read-only lookups this skill relies on:
 
-| Purpose                  | Command                                                    |
-|--------------------------|------------------------------------------------------------|
-| Check if App exists      | `hawkop app list --format json`                            |
-| Check if Env exists      | `hawkop env list --app <APP_ID> --format json`             |
-| Get findings with triage | `hawkop scan get --app <NAME> --detail full --format json` |
+| Purpose                       | Command                                                                          |
+|-------------------------------|----------------------------------------------------------------------------------|
+| Check if App exists           | `hawkop app list --format json`                                                  |
+| Check if Env exists           | `hawkop env list --app <APP_ID> --format json`                                   |
+| Get findings with triage      | `hawkop scan get --app <NAME> --detail full --format json`                       |
+| List ASM repos                | `hawkop repo list --format json`                                                 |
+| Link app to ASM repo          | `hawkop repo link --repo-id <ID> --app-id <ID>`                                  |
+| Get tech flags                | `hawkop app tech-flags get --app <NAME> --format json`                           |
+| Disable all tech flags        | `hawkop app tech-flags disable-all --app <NAME> --yes`                           |
+| Set specific tech flags       | `hawkop app tech-flags set --app <NAME> Key=true`                                |
+| Triage a finding              | `hawkop scan triage --scan <ID> --hash <HASH> --status false-positive --note ""` |
+| Bulk triage from file         | `hawkop scan triage --scan <ID> --from-file triage.yaml`                         |
 
 If `hawkop` is not installed, the api skill documents raw REST fallbacks.
 Prefer `hawkop`; fall back only if unavailable.
@@ -59,6 +66,83 @@ Before running a scan, the agent must understand four layered objects:
   Step 4.5.
 
 → Deep reference: [`references/platform-model.md`](references/platform-model.md)
+
+---
+
+## Phase 0: App Setup & Verification
+
+Run Phase 0 **once** when onboarding a new application — i.e., when `stackhawk.yml`
+is being created for the first time, or when the user explicitly requests
+setup/verification. Do NOT run on every scan.
+
+Phase 0 has three sub-steps. Run them in order.
+
+---
+
+### Phase 0a: Repo Linking
+
+Associates the StackHawk application with its code repository in Attack Surface
+Management (ASM). Enables API Discovery tracking and SCM-driven automapping.
+
+```bash
+# 1. Get the git remote URL
+git remote get-url origin
+# If this fails (no git repo, no origin remote): skip Phase 0a, proceed to Phase 0b
+
+# 2. List ASM repos and normalize URLs to find a match
+hawkop repo list --format json
+
+# 3a. If a repo URL matches (normalize: lowercase, strip .git, strip trailing /,
+#     strip host prefix to compare org/repo path segment):
+hawkop repo link --repo-id <REPO_UUID> --app-id <APP_UUID>
+# Report: "Ensured link: app <APP_NAME> ↔ ASM repo <REPO_NAME>"
+
+# 3b. If no match: inject git_origin tag into stackhawk.yml tags block
+#   tags:
+#     - name: git_origin
+#       value: <bare-org/repo-path>    # bare path after normalization
+# Report: "No ASM repo match — added git_origin tag for future automapping"
+```
+
+→ Full normalization rules, SSH/HTTPS edge cases, and examples:
+  [`references/repo-linking.md`](references/repo-linking.md)
+
+---
+
+### Phase 0b: Agent Tagging
+
+Writes a `_STACKHAWK_AGENT` tag placeholder into `stackhawk.yml` once. At scan
+time (Step 3), the agent detects its platform and exports `HAWK_AGENT` — the
+placeholder interpolates automatically.
+
+Add to `stackhawk.yml` tags block if not already present:
+
+```yaml
+tags:
+  - name: _STACKHAWK_AGENT
+    value: ${HAWK_AGENT:none}
+```
+
+The `:none` default means scans where `HAWK_AGENT` is not set record `none`
+rather than failing interpolation.
+
+---
+
+### Phase 0c: Tech Flag Detection
+
+Configures which scan rule families run for this application. The platform
+defaults all flags to `true`; Phase 0c starts clean and enables only detected techs.
+
+**Algorithm (abbreviated):**
+1. Detect codebase evidence first (package.json, pom.xml, go.mod, requirements.txt,
+   docker-compose.yml, Gemfile, *.csproj)
+2. If no evidence found: skip — do not touch flags
+3. Fetch canonical flag names: `hawkop app tech-flags get --app <APP_NAME> --format json`
+4. Disable all: `hawkop app tech-flags disable-all --app <APP_NAME> --yes`
+5. Enable detected: `hawkop app tech-flags set --app <APP_NAME> Language.Java=true ...`
+
+→ Full detection heuristics, terminal-segment matching, and edge cases:
+  [`references/tech-flags.md`](references/tech-flags.md)
 
 ---
 
@@ -181,7 +265,27 @@ Always validate config before scanning — it's fast and catches problems withou
 burning a full scan run.
 
 ```bash
-# Validate stackhawk.yml structure and required fields
+export COMMIT_SHA=$(git rev-parse HEAD)
+export BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
+# Detect agent platform for _STACKHAWK_AGENT tag interpolation
+# Skip detection if HAWK_AGENT is already set (allows CI/CD override)
+if [ -z "${HAWK_AGENT}" ]; then
+  if [ -n "${CLAUDE_CODE}" ] || [ -d ".claude" ]; then
+    export HAWK_AGENT=claude-code
+  elif [ -n "${CURSOR_TRACE_ID}" ] || [ -d ".cursor" ]; then
+    export HAWK_AGENT=cursor
+  elif [ -f "GEMINI.md" ] || [ -n "${GEMINI_API_KEY}" ]; then
+    export HAWK_AGENT=gemini
+  elif [ -d ".codex" ]; then
+    export HAWK_AGENT=codex
+  elif [ -f ".github/copilot-instructions.md" ]; then
+    export HAWK_AGENT=copilot
+  else
+    export HAWK_AGENT=unknown
+  fi
+fi
+
 hawk validate config stackhawk.yml
 
 # Validate OpenAPI specification referenced in stackhawk.yml
@@ -320,22 +424,49 @@ filter by the per-path triage status (JSON field `findings[].paths[].status`
   pending-triage.
 - **FIX** paths where `status` is `NEW` in normal severity order.
 
-### If you're confident a New finding is a true false positive
+### Marking false positives via `hawkop scan triage`
 
-Do NOT suppress it in the codebase. The platform does not expose a
-triage-write API today — only the platform UI can set `FALSE_POSITIVE` /
-`RISK_ACCEPTED` / `ASSIGNED` decisions. Surface it in the scan report:
+If a `NEW` finding is clearly a false positive, mark it via the platform API
+**before** routing remaining findings to the fix loop.
 
-> Finding `<name>` at `<path>` appears to be a false positive. Mark it at
-> `https://app.stackhawk.com/scans/<scanId>`
+**Common false-positive patterns:**
+- Security headers (CSP, X-Frame-Options) on endpoints that only serve non-HTML responses (JSON, binary)
+- Health / status / actuator endpoints that intentionally expose server info
+- CORS permissiveness on intentionally public APIs with no sensitive data
+- Rate-limit findings on endpoints already enforced by an upstream API gateway
+- Auth findings on intentionally unauthenticated endpoints (login page, public docs)
 
-(Platform gap captured internally; not in this public repo.)
+**Single finding:**
+```bash
+hawkop scan triage \
+  --scan <SCAN_UUID> \
+  --hash <FINDING_HASH> \
+  --status false-positive \
+  --note "CSP finding on JSON endpoint /api/health which never serves HTML; inapplicable"
+```
 
-→ See `references/false-positives.md` for config-based suppression
-  patterns (excludePaths, excluded scan plugins) — useful for scan noise
-  that should never reach the triage pipeline in the first place. Step 4.5
-  is about per-finding triage from the platform; `false-positives.md` is
-  about scope-level config.
+**Batch (multiple FPs in one scan):**
+```bash
+# Write a triage.yaml with one entry per false positive, then:
+hawkop scan triage --scan <SCAN_UUID> --from-file triage.yaml
+```
+
+**Rules:**
+- ✅ Mark `FALSE_POSITIVE` autonomously — note must clearly explain why
+- ✅ Use `ADD_COMMENT` to annotate without changing status
+- ❌ **Never mark `RISK_ACCEPTED`** — human decision only
+- ❌ **Never mark `ASSIGNED`** — human decision only
+- ❌ Do NOT suppress findings in the codebase — don't change code to hide scanner results
+
+**When uncertain:** route to the fix loop. A false negative is worse than a false positive.
+
+After Step 4.5 triage completes, report before the fix loop:
+> "Marked [N] findings as false positive. Routing [M] remaining NEW findings to fix loop."
+> "Platform: https://app.stackhawk.com/scans/<scanId>"
+
+→ See `references/false-positives.md` for config-based suppression patterns
+  (`excludePaths`, `excludePlugins`) — use those for structural noise that should
+  never enter the triage pipeline. Step 4.5 handles per-finding triage decisions.
 
 ---
 
@@ -394,9 +525,11 @@ After completing a code change, announce and execute:
 2. **Configure:** Before generating or reusing `stackhawk.yml`, verify the
    App and Env exist via Step 1 substeps 5–6 — this prevents duplicate App
    creation on every autonomous run. Then, if no `stackhawk.yml` exists,
-   generate one (Step 2a above). If one exists, ensure it has commit SHA
-   tags (top-level, not under `app:`) so scan results are linked to the
-   commit:
+   generate one (Step 2a above) and **immediately run Phase 0** (repo linking,
+   agent tagging, tech flag detection) — this is app onboarding. If one exists,
+   ensure it has commit SHA tags (top-level, not under `app:`) so scan results
+   are linked to the commit, and also ensure the `_STACKHAWK_AGENT` tag (using
+   `${HAWK_AGENT:none}`) is present alongside the commit SHA tags:
    ```yaml
    tags:
      - name: _STACKHAWK_GIT_COMMIT_SHA
@@ -408,6 +541,25 @@ After completing a code change, announce and execute:
    ```bash
    export COMMIT_SHA=$(git rev-parse HEAD)
    export BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
+   # Detect agent platform for _STACKHAWK_AGENT tag interpolation
+   # Skip detection if HAWK_AGENT is already set (allows CI/CD override)
+   if [ -z "${HAWK_AGENT}" ]; then
+     if [ -n "${CLAUDE_CODE}" ] || [ -d ".claude" ]; then
+       export HAWK_AGENT=claude-code
+     elif [ -n "${CURSOR_TRACE_ID}" ] || [ -d ".cursor" ]; then
+       export HAWK_AGENT=cursor
+     elif [ -f "GEMINI.md" ] || [ -n "${GEMINI_API_KEY}" ]; then
+       export HAWK_AGENT=gemini
+     elif [ -d ".codex" ]; then
+       export HAWK_AGENT=codex
+     elif [ -f ".github/copilot-instructions.md" ]; then
+       export HAWK_AGENT=copilot
+     else
+       export HAWK_AGENT=unknown
+     fi
+   fi
+
    hawk validate config stackhawk.yml
    ```
 4. **Scan:** Run `hawk scan --json-output` and parse the structured findings. The scan
@@ -448,9 +600,9 @@ After completing a code change, announce and execute:
    - If any findings were filtered by Step 4.5 triage state, append a
      one-line summary: "Skipped [X] findings already triaged as
      RISK_ACCEPTED / FALSE_POSITIVE."
-   - If any suspected false positives were identified during fixing, list
-     them with the `https://app.stackhawk.com/scans/<scanId>` platform link
-     so a human can triage them in the platform UI.
+   - If any findings were marked `FALSE_POSITIVE` in Step 4.5, summarize:
+     "Marked [N] findings as false positive — review at
+     https://app.stackhawk.com/scans/<scanId>".
 
 ### Guard Rails
 

--- a/plugins/api/skills/api/references/hawkop-shortcuts.md
+++ b/plugins/api/skills/api/references/hawkop-shortcuts.md
@@ -8,13 +8,54 @@ See `SKILL.md` for the workflow that decides when to use `hawkop` vs raw REST.
 
 ## Setup (once)
 
+**Homebrew (macOS/Linux — recommended):**
 ```bash
-# Install (macOS / Linux)
 brew tap stackhawk/hawkop && brew install hawkop
+```
 
-# Or download signed artifacts directly from https://download.stackhawk.com/hawkop/
-# See https://docs.stackhawk.com/hawkop/#installation
+**Direct downloads:** `https://download.stackhawk.com/hawkop/`
+Downloads page: `https://docs.stackhawk.com/downloads/hawkop/`
 
+Check the current version:
+```bash
+curl -s https://download.stackhawk.com/hawkop/latest-version.txt
+```
+
+**macOS — PKG installer (universal, includes all architectures):**
+```bash
+VERSION=$(curl -s https://download.stackhawk.com/hawkop/latest-version.txt)
+curl -Lo hawkop.pkg "https://download.stackhawk.com/hawkop/pkg/hawkop-v${VERSION}-macos-universal.pkg"
+open hawkop.pkg
+```
+
+**Windows — MSI installer:**
+```powershell
+$Version = (Invoke-WebRequest https://download.stackhawk.com/hawkop/latest-version.txt).Content.Trim()
+Invoke-WebRequest "https://download.stackhawk.com/hawkop/msi/hawkop-v$Version-windows-x64.msi" -OutFile hawkop.msi
+Start-Process msiexec.exe -ArgumentList "/i hawkop.msi /passive" -Wait
+```
+
+**Linux / archive installs** (base: `https://download.stackhawk.com/hawkop/cli/`):
+
+| Platform | Filename |
+|----------|----------|
+| macOS Intel | `hawkop-v{VERSION}-x86_64-apple-darwin.tar.gz` |
+| macOS Apple Silicon | `hawkop-v{VERSION}-aarch64-apple-darwin.tar.gz` |
+| Linux x86_64 | `hawkop-v{VERSION}-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux ARM64 | `hawkop-v{VERSION}-aarch64-unknown-linux-gnu.tar.gz` |
+| Windows x86_64 | `hawkop-v{VERSION}-x86_64-pc-windows-msvc.zip` |
+
+Each archive has a matching `.sha256` checksum file at the same URL path.
+
+```bash
+# No runtime dependencies — native binary, just extract and run
+VERSION=$(curl -s https://download.stackhawk.com/hawkop/latest-version.txt)
+curl -Lo hawkop.tar.gz "https://download.stackhawk.com/hawkop/cli/hawkop-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+tar -xzf hawkop.tar.gz
+sudo mv hawkop /usr/local/bin/
+```
+
+```bash
 hawkop init            # Interactive — prompts for API key and default org
 hawkop status          # Confirm auth
 ```

--- a/plugins/hawkscan/skills/hawkscan/SKILL.md
+++ b/plugins/hawkscan/skills/hawkscan/SKILL.md
@@ -268,7 +268,27 @@ Always validate config before scanning — it's fast and catches problems withou
 burning a full scan run.
 
 ```bash
-# Validate stackhawk.yml structure and required fields
+export COMMIT_SHA=$(git rev-parse HEAD)
+export BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
+# Detect agent platform for _STACKHAWK_AGENT tag interpolation
+# Skip detection if HAWK_AGENT is already set (allows CI/CD override)
+if [ -z "${HAWK_AGENT}" ]; then
+  if [ -n "${CLAUDE_CODE}" ] || [ -d ".claude" ]; then
+    export HAWK_AGENT=claude-code
+  elif [ -n "${CURSOR_TRACE_ID}" ] || [ -d ".cursor" ]; then
+    export HAWK_AGENT=cursor
+  elif [ -f "GEMINI.md" ] || [ -n "${GEMINI_API_KEY}" ]; then
+    export HAWK_AGENT=gemini
+  elif [ -d ".codex" ]; then
+    export HAWK_AGENT=codex
+  elif [ -f ".github/copilot-instructions.md" ]; then
+    export HAWK_AGENT=copilot
+  else
+    export HAWK_AGENT=unknown
+  fi
+fi
+
 hawk validate config stackhawk.yml
 
 # Validate OpenAPI specification referenced in stackhawk.yml
@@ -407,22 +427,49 @@ filter by the per-path triage status (JSON field `findings[].paths[].status`
   pending-triage.
 - **FIX** paths where `status` is `NEW` in normal severity order.
 
-### If you're confident a New finding is a true false positive
+### Marking false positives via `hawkop scan triage`
 
-Do NOT suppress it in the codebase. The platform does not expose a
-triage-write API today — only the platform UI can set `FALSE_POSITIVE` /
-`RISK_ACCEPTED` / `ASSIGNED` decisions. Surface it in the scan report:
+If a `NEW` finding is clearly a false positive, mark it via the platform API
+**before** routing remaining findings to the fix loop.
 
-> Finding `<name>` at `<path>` appears to be a false positive. Mark it at
-> `https://app.stackhawk.com/scans/<scanId>`
+**Common false-positive patterns:**
+- Security headers (CSP, X-Frame-Options) on endpoints that only serve non-HTML responses (JSON, binary)
+- Health / status / actuator endpoints that intentionally expose server info
+- CORS permissiveness on intentionally public APIs with no sensitive data
+- Rate-limit findings on endpoints already enforced by an upstream API gateway
+- Auth findings on intentionally unauthenticated endpoints (login page, public docs)
 
-(Platform gap captured internally; not in this public repo.)
+**Single finding:**
+```bash
+hawkop scan triage \
+  --scan <SCAN_UUID> \
+  --hash <FINDING_HASH> \
+  --status false-positive \
+  --note "CSP finding on JSON endpoint /api/health which never serves HTML; inapplicable"
+```
 
-→ See `references/false-positives.md` for config-based suppression
-  patterns (excludePaths, excluded scan plugins) — useful for scan noise
-  that should never reach the triage pipeline in the first place. Step 4.5
-  is about per-finding triage from the platform; `false-positives.md` is
-  about scope-level config.
+**Batch (multiple FPs in one scan):**
+```bash
+# Write a triage.yaml with one entry per false positive, then:
+hawkop scan triage --scan <SCAN_UUID> --from-file triage.yaml
+```
+
+**Rules:**
+- ✅ Mark `FALSE_POSITIVE` autonomously — note must clearly explain why
+- ✅ Use `ADD_COMMENT` to annotate without changing status
+- ❌ **Never mark `RISK_ACCEPTED`** — human decision only
+- ❌ **Never mark `ASSIGNED`** — human decision only
+- ❌ Do NOT suppress findings in the codebase — don't change code to hide scanner results
+
+**When uncertain:** route to the fix loop. A false negative is worse than a false positive.
+
+After Step 4.5 triage completes, report before the fix loop:
+> "Marked [N] findings as false positive. Routing [M] remaining NEW findings to fix loop."
+> "Platform: https://app.stackhawk.com/scans/<scanId>"
+
+→ See `references/false-positives.md` for config-based suppression patterns
+  (`excludePaths`, `excludePlugins`) — use those for structural noise that should
+  never enter the triage pipeline. Step 4.5 handles per-finding triage decisions.
 
 ---
 
@@ -481,9 +528,11 @@ After completing a code change, announce and execute:
 2. **Configure:** Before generating or reusing `stackhawk.yml`, verify the
    App and Env exist via Step 1 substeps 5–6 — this prevents duplicate App
    creation on every autonomous run. Then, if no `stackhawk.yml` exists,
-   generate one (Step 2a above). If one exists, ensure it has commit SHA
-   tags (top-level, not under `app:`) so scan results are linked to the
-   commit:
+   generate one (Step 2a above) and **immediately run Phase 0** (repo linking,
+   agent tagging, tech flag detection) — this is app onboarding. If one exists,
+   ensure it has commit SHA tags (top-level, not under `app:`) so scan results
+   are linked to the commit, and also ensure the `_STACKHAWK_AGENT` tag (using
+   `${HAWK_AGENT:none}`) is present alongside the commit SHA tags:
    ```yaml
    tags:
      - name: _STACKHAWK_GIT_COMMIT_SHA
@@ -495,6 +544,25 @@ After completing a code change, announce and execute:
    ```bash
    export COMMIT_SHA=$(git rev-parse HEAD)
    export BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+
+   # Detect agent platform for _STACKHAWK_AGENT tag interpolation
+   # Skip detection if HAWK_AGENT is already set (allows CI/CD override)
+   if [ -z "${HAWK_AGENT}" ]; then
+     if [ -n "${CLAUDE_CODE}" ] || [ -d ".claude" ]; then
+       export HAWK_AGENT=claude-code
+     elif [ -n "${CURSOR_TRACE_ID}" ] || [ -d ".cursor" ]; then
+       export HAWK_AGENT=cursor
+     elif [ -f "GEMINI.md" ] || [ -n "${GEMINI_API_KEY}" ]; then
+       export HAWK_AGENT=gemini
+     elif [ -d ".codex" ]; then
+       export HAWK_AGENT=codex
+     elif [ -f ".github/copilot-instructions.md" ]; then
+       export HAWK_AGENT=copilot
+     else
+       export HAWK_AGENT=unknown
+     fi
+   fi
+
    hawk validate config stackhawk.yml
    ```
 4. **Scan:** Run `hawk scan --json-output` and parse the structured findings. The scan
@@ -535,9 +603,9 @@ After completing a code change, announce and execute:
    - If any findings were filtered by Step 4.5 triage state, append a
      one-line summary: "Skipped [X] findings already triaged as
      RISK_ACCEPTED / FALSE_POSITIVE."
-   - If any suspected false positives were identified during fixing, list
-     them with the `https://app.stackhawk.com/scans/<scanId>` platform link
-     so a human can triage them in the platform UI.
+   - If any findings were marked `FALSE_POSITIVE` in Step 4.5, summarize:
+     "Marked [N] findings as false positive — review at
+     https://app.stackhawk.com/scans/<scanId>".
 
 ### Guard Rails
 

--- a/plugins/hawkscan/skills/hawkscan/SKILL.md
+++ b/plugins/hawkscan/skills/hawkscan/SKILL.md
@@ -24,11 +24,18 @@ coding loop. The core workflow is:
 The `api` skill wraps read-only StackHawk platform lookups via the `hawkop`
 CLI. Read-only lookups this skill relies on:
 
-| Purpose                  | Command                                                    |
-|--------------------------|------------------------------------------------------------|
-| Check if App exists      | `hawkop app list --format json`                            |
-| Check if Env exists      | `hawkop env list --app <APP_ID> --format json`             |
-| Get findings with triage | `hawkop scan get --app <NAME> --detail full --format json` |
+| Purpose                       | Command                                                                          |
+|-------------------------------|----------------------------------------------------------------------------------|
+| Check if App exists           | `hawkop app list --format json`                                                  |
+| Check if Env exists           | `hawkop env list --app <APP_ID> --format json`                                   |
+| Get findings with triage      | `hawkop scan get --app <NAME> --detail full --format json`                       |
+| List ASM repos                | `hawkop repo list --format json`                                                 |
+| Link app to ASM repo          | `hawkop repo link --repo-id <ID> --app-id <ID>`                                  |
+| Get tech flags                | `hawkop app tech-flags get --app <NAME> --format json`                           |
+| Disable all tech flags        | `hawkop app tech-flags disable-all --app <NAME> --yes`                           |
+| Set specific tech flags       | `hawkop app tech-flags set --app <NAME> Key=true`                                |
+| Triage a finding              | `hawkop scan triage --scan <ID> --hash <HASH> --status false-positive --note ""` |
+| Bulk triage from file         | `hawkop scan triage --scan <ID> --from-file triage.yaml`                         |
 
 If `hawkop` is not installed, the api skill documents raw REST fallbacks.
 Prefer `hawkop`; fall back only if unavailable.
@@ -62,6 +69,83 @@ Before running a scan, the agent must understand four layered objects:
   Step 4.5.
 
 → Deep reference: [`references/platform-model.md`](references/platform-model.md)
+
+---
+
+## Phase 0: App Setup & Verification
+
+Run Phase 0 **once** when onboarding a new application — i.e., when `stackhawk.yml`
+is being created for the first time, or when the user explicitly requests
+setup/verification. Do NOT run on every scan.
+
+Phase 0 has three sub-steps. Run them in order.
+
+---
+
+### Phase 0a: Repo Linking
+
+Associates the StackHawk application with its code repository in Attack Surface
+Management (ASM). Enables API Discovery tracking and SCM-driven automapping.
+
+```bash
+# 1. Get the git remote URL
+git remote get-url origin
+# If this fails (no git repo, no origin remote): skip Phase 0a, proceed to Phase 0b
+
+# 2. List ASM repos and normalize URLs to find a match
+hawkop repo list --format json
+
+# 3a. If a repo URL matches (normalize: lowercase, strip .git, strip trailing /,
+#     strip host prefix to compare org/repo path segment):
+hawkop repo link --repo-id <REPO_UUID> --app-id <APP_UUID>
+# Report: "Ensured link: app <APP_NAME> ↔ ASM repo <REPO_NAME>"
+
+# 3b. If no match: inject git_origin tag into stackhawk.yml tags block
+#   tags:
+#     - name: git_origin
+#       value: <bare-org/repo-path>    # bare path after normalization
+# Report: "No ASM repo match — added git_origin tag for future automapping"
+```
+
+→ Full normalization rules, SSH/HTTPS edge cases, and examples:
+  [`references/repo-linking.md`](references/repo-linking.md)
+
+---
+
+### Phase 0b: Agent Tagging
+
+Writes a `_STACKHAWK_AGENT` tag placeholder into `stackhawk.yml` once. At scan
+time (Step 3), the agent detects its platform and exports `HAWK_AGENT` — the
+placeholder interpolates automatically.
+
+Add to `stackhawk.yml` tags block if not already present:
+
+```yaml
+tags:
+  - name: _STACKHAWK_AGENT
+    value: ${HAWK_AGENT:none}
+```
+
+The `:none` default means scans where `HAWK_AGENT` is not set record `none`
+rather than failing interpolation.
+
+---
+
+### Phase 0c: Tech Flag Detection
+
+Configures which scan rule families run for this application. The platform
+defaults all flags to `true`; Phase 0c starts clean and enables only detected techs.
+
+**Algorithm (abbreviated):**
+1. Detect codebase evidence first (package.json, pom.xml, go.mod, requirements.txt,
+   docker-compose.yml, Gemfile, *.csproj)
+2. If no evidence found: skip — do not touch flags
+3. Fetch canonical flag names: `hawkop app tech-flags get --app <APP_NAME> --format json`
+4. Disable all: `hawkop app tech-flags disable-all --app <APP_NAME> --yes`
+5. Enable detected: `hawkop app tech-flags set --app <APP_NAME> Language.Java=true ...`
+
+→ Full detection heuristics, terminal-segment matching, and edge cases:
+  [`references/tech-flags.md`](references/tech-flags.md)
 
 ---
 

--- a/plugins/hawkscan/skills/hawkscan/references/false-positives.md
+++ b/plugins/hawkscan/skills/hawkscan/references/false-positives.md
@@ -49,15 +49,21 @@ app:
     - /assets
 ```
 
-### Set failure threshold to ignore Low-severity findings
+### Control which severity triggers exit code 42
+
+`failureThreshold` belongs under `hawk:` — **never under `app:`**.
 
 ```yaml
 hawk:
-  failureThreshold: MEDIUM
+  failureThreshold: MEDIUM   # LOW | MEDIUM | HIGH
 ```
 
-This means the scan still reports Low findings but exits with code `0` instead of
-`42` — they won't trigger the fix loop.
+The scan always reports all findings regardless of this setting. `failureThreshold`
+only controls the exit code: the scan exits `42` (triggering the fix loop) when a
+finding at or above the threshold is found; otherwise it exits `0`.
+
+Use this to gate CI pipelines by severity — for example, allow Low findings to pass
+without triggering the fix loop while still recording them in the platform.
 
 ### Exclude specific scan plugins
 

--- a/plugins/hawkscan/skills/hawkscan/references/false-positives.md
+++ b/plugins/hawkscan/skills/hawkscan/references/false-positives.md
@@ -82,7 +82,7 @@ hawkop scan triage \
   --scan <SCAN_UUID> \
   --hash <FINDING_HASH> \
   --status false-positive \
-  --note "<reason — be specific: endpoint, finding name, why it's wrong>"
+  --note "<reason — explain specifically why the scanner is wrong>"
 ```
 
 Example notes:

--- a/plugins/hawkscan/skills/hawkscan/references/false-positives.md
+++ b/plugins/hawkscan/skills/hawkscan/references/false-positives.md
@@ -61,17 +61,101 @@ hawk:
 
 Use this sparingly. Prefer path exclusions over disabling entire plugins.
 
+## Triaging via the API
+
+Use `hawkop scan triage` to record false-positive decisions on the platform.
+This is the preferred action over config suppression when the finding is a true
+false positive — it creates an auditable, human-reviewable record.
+
+### When to use API triage vs. config suppression
+
+| Scenario | Action |
+|----------|--------|
+| Scanner is definitively wrong about this endpoint | **API triage** → `false-positive` with note |
+| Path should permanently be excluded from scanning | **Config** → `excludePaths` in `stackhawk.yml` |
+| Finding is noisy but not clearly wrong | **Fix it** — when in doubt, fix |
+| Both apply (wrong AND should never scan) | Do both: triage existing finding + add to `excludePaths` |
+
+### Single finding
+
+```bash
+hawkop scan triage \
+  --scan <SCAN_UUID> \
+  --hash <FINDING_HASH> \
+  --status false-positive \
+  --note "<reason — be specific: endpoint, finding name, why it's wrong>"
+```
+
+Example notes:
+- `"CSP finding on JSON endpoint /api/health which never serves HTML; header inapplicable"`
+- `"CORS wildcard on public read-only metrics API; no auth, no sensitive data"`
+- `"Rate-limit finding on /api/events; rate limiting enforced at API gateway layer"`
+
+### Bulk (multiple findings in one scan)
+
+Write a `triage.yaml`:
+```yaml
+- finding_hash: "sha256hash1"
+  status: FALSE_POSITIVE
+  note: "Health endpoint — intentional server info exposure for monitoring"
+- finding_hash: "sha256hash2"
+  status: FALSE_POSITIVE
+  note: "CORS permissive by design; public read-only API"
+```
+
+Then apply:
+```bash
+hawkop scan triage --scan <SCAN_UUID> --from-file triage.yaml
+```
+
+JSON format is also accepted (leading `[` is auto-detected). Max 100 actions per call — split into batches if needed.
+
+### Agent rules for API triage
+
+- ✅ Mark `FALSE_POSITIVE` autonomously — note must explain clearly why
+- ✅ Use `ADD_COMMENT` to annotate without changing status
+- ❌ **Never mark `RISK_ACCEPTED`** — human decision only
+- ❌ **Never mark `ASSIGNED`** — human decision only
+- ❌ Never suppress a finding by changing code to hide it from the scanner
+
+```bash
+# ADD_COMMENT example — for findings under review but not yet confirmed FP
+hawkop scan triage \
+  --scan <SCAN_UUID> \
+  --hash <FINDING_HASH> \
+  --status add-comment \
+  --note "Reviewing with team; suspected false positive on /actuator/info"
+```
+
+### How to get the finding hash
+
+The finding hash (`--hash`) comes from the scan JSON output:
+```bash
+hawk scan --json-output | jq '.findings[].hash'
+```
+
+Or from `hawkop scan get`:
+```bash
+hawkop scan get --app <APP_NAME> --detail full --format json | jq '.data.findings[].hash'
+```
+
+The scan UUID (`--scan`) comes from:
+```bash
+hawk scan --json-output | jq -r '.scan.id'
+```
+
 ## Reporting Accepted Risk
 
-When you encounter a finding that is a known false positive or accepted risk:
+When you encounter a finding that is a known false positive:
 
 1. **Do not "fix" intentional behavior.** Changing a deliberately open health endpoint
    to require auth will break monitoring.
-2. **Add the path to `excludePaths`** in `stackhawk.yml` so it doesn't trigger again.
-3. **Report it clearly:** "Finding X on path Y is an accepted risk because [reason].
-   Added to excludePaths to prevent future false positives."
-4. **If the StackHawk platform is available**, triage the finding as "Accepted Risk"
-   with a note explaining why.
+2. **Triage via the API** using `hawkop scan triage` (see section above) so the decision
+   is recorded and auditable.
+3. **Optionally add the path to `excludePaths`** in `stackhawk.yml` to prevent it from
+   appearing on future scans — useful for paths that should never be scanned.
+4. **Report it clearly:** "Finding X on path Y is a false positive because [reason].
+   Marked via API triage with note: [note]."
 
 ## When in Doubt
 

--- a/plugins/hawkscan/skills/hawkscan/references/false-positives.md
+++ b/plugins/hawkscan/skills/hawkscan/references/false-positives.md
@@ -72,9 +72,8 @@ false positive — it creates an auditable, human-reviewable record.
 | Scenario | Action |
 |----------|--------|
 | Scanner is definitively wrong about this endpoint | **API triage** → `false-positive` with note |
-| Path should permanently be excluded from scanning | **Config** → `excludePaths` in `stackhawk.yml` |
+| Finding is real but uncertain — needs more review | **API triage** → `add-comment` with context |
 | Finding is noisy but not clearly wrong | **Fix it** — when in doubt, fix |
-| Both apply (wrong AND should never scan) | Do both: triage existing finding + add to `excludePaths` |
 
 ### Single finding
 
@@ -152,9 +151,7 @@ When you encounter a finding that is a known false positive:
    to require auth will break monitoring.
 2. **Triage via the API** using `hawkop scan triage` (see section above) so the decision
    is recorded and auditable.
-3. **Optionally add the path to `excludePaths`** in `stackhawk.yml` to prevent it from
-   appearing on future scans — useful for paths that should never be scanned.
-4. **Report it clearly:** "Finding X on path Y is a false positive because [reason].
+3. **Report it clearly:** "Finding X on path Y is a false positive because [reason].
    Marked via API triage with note: [note]."
 
 ## When in Doubt

--- a/plugins/hawkscan/skills/hawkscan/references/false-positives.md
+++ b/plugins/hawkscan/skills/hawkscan/references/false-positives.md
@@ -29,6 +29,15 @@ scenarios:
 
 ### Exclude specific paths from scanning
 
+The scanner is pinned to the `host:` value in `stackhawk.yml` and will not
+traverse to other hosts. You do **not** need to add external domains or CDN
+URLs to `excludePaths` — the scanner won't follow them.
+
+Use `excludePaths` for same-host paths that generate noise without security
+value: static assets (images, CSS, JavaScript bundles), health endpoints,
+API docs, and similar paths that are either not user-controllable or not
+relevant to security testing.
+
 ```yaml
 app:
   excludePaths:
@@ -36,6 +45,8 @@ app:
     - /actuator/info
     - /swagger-ui
     - /api-docs
+    - /static
+    - /assets
 ```
 
 ### Set failure threshold to ignore Low-severity findings

--- a/plugins/hawkscan/skills/hawkscan/references/installation.md
+++ b/plugins/hawkscan/skills/hawkscan/references/installation.md
@@ -11,10 +11,39 @@ brew install hawk
 
 ### Package Installers (All Platforms)
 
-Download platform-specific installers from https://docs.stackhawk.com/downloads/:
-- **macOS:** `.pkg` installer or `.zip` (includes bundled Java)
-- **Windows:** Windows installer (includes bundled Java)
-- **Linux:** `.zip` package (may require Java 17+ installed separately)
+Downloads page: https://docs.stackhawk.com/downloads/
+
+Check the current version:
+```bash
+curl -s https://api.stackhawk.com/hawkscan/version
+# → 5.5.0
+```
+
+**macOS — PKG installer (includes bundled Java, recommended):**
+```bash
+HAWK_VERSION=$(curl -s https://api.stackhawk.com/hawkscan/version)
+curl -Lo hawk.pkg "https://download.stackhawk.com/hawk/pkg/hawk-${HAWK_VERSION}.pkg"
+sudo installer -pkg hawk.pkg -target /Applications
+```
+
+**Windows — MSI installer (includes bundled Java):**
+```powershell
+$version = Invoke-RestMethod https://api.stackhawk.com/hawkscan/version
+msiexec.exe /i "https://download.stackhawk.com/hawk/msi/hawk-${version}.msi" /passive
+```
+
+**Linux / All Platforms — ZIP (requires Java 17+ installed separately):**
+```bash
+HAWK_VERSION=$(curl -s https://api.stackhawk.com/hawkscan/version)
+curl -Lo hawk.zip "https://download.stackhawk.com/hawk/cli/hawk-${HAWK_VERSION}.zip"
+unzip hawk.zip
+echo "export PATH=\$HOME/hawk-${HAWK_VERSION}:\$PATH" >> ~/.zshrc && source ~/.zshrc
+```
+
+Direct download URL patterns (substitute version):
+- macOS PKG: `https://download.stackhawk.com/hawk/pkg/hawk-{VERSION}.pkg`
+- Windows MSI: `https://download.stackhawk.com/hawk/msi/hawk-{VERSION}.msi`
+- ZIP (all): `https://download.stackhawk.com/hawk/cli/hawk-{VERSION}.zip`
 
 ### Prerequisites
 

--- a/plugins/hawkscan/skills/hawkscan/references/platform-model.md
+++ b/plugins/hawkscan/skills/hawkscan/references/platform-model.md
@@ -126,17 +126,42 @@ on a later scan, the platform continues to report its current triage
 value (`FALSE_POSITIVE` / `RISK_ACCEPTED` stays sticky unless a human
 changes it).
 
-### The agent cannot write triage
+### What the agent can write via `hawkop scan triage`
 
-There is no API today for setting `FALSE_POSITIVE` / `RISK_ACCEPTED` /
-`ASSIGNED` programmatically. If the agent is confident a `NEW` finding is
-a true false positive, the right behavior is to **report** it in the scan
-summary with a link to `https://app.stackhawk.com/scans/<scanId>` so a
-human can triage it in the platform UI. Do NOT suppress it in the
-codebase — that would make future scans invisible.
+The `hawkop` CLI exposes triage writes. Use these in Step 4.5 of the scan
+loop when the agent identifies clear false positives.
 
-(Tracked internally as a platform-team ask; not documented in this public
-repo.)
+```bash
+# Mark a single finding path as a false positive (--note required)
+hawkop scan triage \
+  --scan <SCAN_UUID> \
+  --hash <FINDING_HASH> \
+  --status false-positive \
+  --note "CSP finding on JSON endpoint /api/health; never serves HTML"
+
+# Add a comment without changing status
+hawkop scan triage \
+  --scan <SCAN_UUID> \
+  --hash <FINDING_HASH> \
+  --status add-comment \
+  --note "Reviewed; confirmed false positive pattern"
+
+# Bulk triage from file (up to 100 actions per call)
+hawkop scan triage --scan <SCAN_UUID> --from-file triage.yaml
+```
+
+**Agent constraints:**
+- ✅ May mark `FALSE_POSITIVE` autonomously — must include a detailed `--note`
+- ✅ May use `ADD_COMMENT` to annotate findings
+- ❌ Must NOT mark `RISK_ACCEPTED` — human decision only
+- ❌ Must NOT mark `ASSIGNED` — human decision only
+- ❌ Do NOT suppress findings in code — do not change code to hide scanner results
+
+The `--note` is required for `FALSE_POSITIVE` and `ADD_COMMENT`.
+It must explain the reasoning clearly enough for a human to review and reverse if wrong.
+
+→ Bulk triage file format and false-positive heuristics:
+  [`references/false-positives.md`](false-positives.md)
 
 ### Exact JSON serialization
 
@@ -210,15 +235,27 @@ https://app.stackhawk.com/applications/<applicationId>/details/settings
 (config); tech flags tell HawkScan *which rules are relevant*. Different
 concerns.
 
-### Setting them today — no API
+### Setting tech flags via `hawkop`
 
-There is no public API for reading or writing tech flags. Setting them is
-a human action in the platform UI. This is a known platform-team gap
-tracked internally.
+Tech flags are set via the `hawkop` CLI during Phase 0 of the scan workflow
+(app onboarding). The process is: disable-all first (to clear the platform's
+all-true default), then enable only what codebase evidence supports.
 
-Until the API exists, the skill does NOT prompt users to set tech flags
-during every scan — that's noise without an API to act on. When the API
-lands, Step 1 of `SKILL.md` will gain a tech-flag reconciliation substep.
+```bash
+# 1. Fetch canonical flag list — API is source of truth for valid names
+hawkop app tech-flags get --app <APP_NAME> --format json
+
+# 2. Disable all (--yes required for non-interactive/agent use)
+hawkop app tech-flags disable-all --app <APP_NAME> --yes
+
+# 3. Enable only detected flags
+hawkop app tech-flags set --app <APP_NAME> Language.Java=true Language.Java.Spring=true
+```
+
+Phase 0 runs once at app onboarding, not on every scan.
+
+→ Full detection heuristics, matching algorithm, and edge cases:
+  [`references/tech-flags.md`](tech-flags.md)
 
 ### Detecting the right flags for a codebase
 

--- a/plugins/hawkscan/skills/hawkscan/references/repo-linking.md
+++ b/plugins/hawkscan/skills/hawkscan/references/repo-linking.md
@@ -1,0 +1,121 @@
+# Repo Linking (Attack Surface Management)
+
+Linking a StackHawk application to its source repository enables API Discovery
+tracking and SCM-driven automapping. Do this once during app onboarding (Phase 0).
+
+## When to Run
+
+- `stackhawk.yml` was just created (new application onboarding)
+- The user explicitly requests setup or verification
+- NOT on every scan — this is app-level setup
+
+## Commands
+
+```bash
+# List all repositories in the org's attack surface
+hawkop repo list --format json
+
+# Link an existing app to a repo (additive — safe to re-run)
+hawkop repo link --repo-id <REPO_UUID> --app-id <APP_UUID>
+
+# Link by app name (creates a new app if the name doesn't exist)
+hawkop repo link --repo-id <REPO_UUID> --app-name "my-api"
+
+# Full replacement (destructive — overwrites all existing app mappings for this repo)
+# Use only if you need to remove a previously linked app
+hawkop repo set-apps --repo-id <REPO_UUID> --app-ids <UUID1>,<UUID2>
+```
+
+**Prefer `repo link` over `repo set-apps`.** The `link` command reads the current
+mappings, merges in the new app, and posts the complete list — existing links are
+preserved. `set-apps` replaces the entire list.
+
+## How to Identify the Repo
+
+1. Get the git remote URL:
+   ```bash
+   git remote get-url origin
+   ```
+
+2. Normalize both the local URL and every `url` field in `hawkop repo list` output:
+   - Lowercase
+   - Strip `.git` suffix
+   - Strip trailing `/`
+
+3. Match on normalized equality.
+
+### Example
+
+Local: `git@github.com:Org/My-Repo.git`
+Normalized: `git@github.com:org/my-repo`
+
+API entry `url`: `https://github.com/Org/My-Repo`
+Normalized: `https://github.com/org/my-repo`
+
+These do NOT match because the scheme and transport differ (`git@` vs `https://`).
+Also strip common prefixes to compare just `org/my-repo`:
+
+```
+git@github.com:org/my-repo   → strip "git@github.com:" → "org/my-repo"
+https://github.com/org/my-repo → strip "https://github.com/" → "org/my-repo"
+```
+
+After stripping the host, compare the path segment (`org/my-repo`). This matches.
+
+## No Match Fallback: `git_origin` Tag
+
+If no repo in the org's attack surface matches the local git remote, do NOT fail —
+inject a `git_origin` tag into `stackhawk.yml` instead:
+
+```yaml
+tags:
+  - name: git_origin
+    value: <normalized-url>
+```
+
+This breadcrumb is visible in every scan from this config. Once the SCM org is
+connected in StackHawk's attack surface, the platform can automap repos to apps
+using the `git_origin` tag values. Use the normalized URL as the value.
+
+### Full Phase 0a Algorithm
+
+```
+1. git remote get-url origin → LOCAL_URL
+2. Normalize LOCAL_URL → NORM_LOCAL
+3. hawkop repo list --format json → REPOS[]
+4. For each repo in REPOS[]:
+     normalize repo.url → NORM_REPO
+     strip host from both → PATH_LOCAL, PATH_REPO
+     if PATH_LOCAL == PATH_REPO:
+       hawkop repo link --repo-id repo.id --app-id <APP_ID>
+       Report: "Linked app <APP_NAME> to ASM repo <REPO_NAME>"
+       DONE
+5. No match found:
+   Inject into stackhawk.yml tags block:
+     - name: git_origin
+       value: NORM_LOCAL
+   Report: "No ASM repo match for NORM_LOCAL — added git_origin tag for future automapping"
+```
+
+## `hawkop repo list` Output Shape
+
+```json
+{
+  "data": [
+    {
+      "id": "uuid",
+      "name": "My-Repo",
+      "url": "https://github.com/Org/My-Repo",
+      "defaultBranch": "main",
+      "frameworkNames": ["Spring Boot", "React"],
+      "appInfos": [
+        { "appId": "uuid", "appName": "my-api" }
+      ]
+    }
+  ]
+}
+```
+
+`frameworkNames` is a bonus signal — if the repo is already known to StackHawk's
+ASM scan, it can inform tech flag detection (Sub-step 0c) even before inspecting
+the local codebase.

--- a/plugins/hawkscan/skills/hawkscan/references/repo-linking.md
+++ b/plugins/hawkscan/skills/hawkscan/references/repo-linking.md
@@ -51,9 +51,8 @@ preserved. `set-apps` replaces the entire list.
    3. Strip trailing `/`
    4. Strip protocol+host prefix to obtain the bare `owner/repo` path:
       - HTTPS: strip `https://github.com/` (or equivalent host prefix)
-      - SSH `git@host:path` form: strip everything up to and including `:`
-      - SSH URL form (`ssh://git@github.com/org/repo`): strip `ssh://` first, then
-        treat as the `git@` form
+      - SSH SCP-like form (`git@host:path`): strip everything up to and including `:`
+      - SSH URL form (`ssh://git@github.com/org/repo`): strip the entire `ssh://git@host/` prefix (everything through the first `/` after the host)
       - Embedded credentials (`https://token@github.com/org/repo`): strip
         credentials before stripping the host (i.e. treat as plain HTTPS)
       - The result is just `org/repo`

--- a/plugins/hawkscan/skills/hawkscan/references/repo-linking.md
+++ b/plugins/hawkscan/skills/hawkscan/references/repo-linking.md
@@ -20,7 +20,14 @@ hawkop repo link --repo-id <REPO_UUID> --app-id <APP_UUID>
 
 # Link by app name (creates a new app if the name doesn't exist)
 hawkop repo link --repo-id <REPO_UUID> --app-name "my-api"
+```
 
+> ⚠️ **Do not use `--app-name` to create applications.** Application creation must
+> go through SKILL.md Step 1 substep 5 (`hawk create app`), which announces the
+> settings URL and records the `applicationId`. Use `--app-id` with an
+> already-resolved UUID instead.
+
+```bash
 # Full replacement (destructive — overwrites all existing app mappings for this repo)
 # Use only if you need to remove a previously linked app
 hawkop repo set-apps --repo-id <REPO_UUID> --app-ids <UUID1>,<UUID2>
@@ -37,30 +44,43 @@ preserved. `set-apps` replaces the entire list.
    git remote get-url origin
    ```
 
-2. Normalize both the local URL and every `url` field in `hawkop repo list` output:
-   - Lowercase
-   - Strip `.git` suffix
-   - Strip trailing `/`
+2. Normalize both the local URL and every `url` field in `hawkop repo list` output
+   using these 4 steps:
+   1. Lowercase
+   2. Strip `.git` suffix
+   3. Strip trailing `/`
+   4. Strip protocol+host prefix to obtain the bare `owner/repo` path:
+      - HTTPS: strip `https://github.com/` (or equivalent host prefix)
+      - SSH `git@host:path` form: strip everything up to and including `:`
+      - SSH URL form (`ssh://git@github.com/org/repo`): strip `ssh://` first, then
+        treat as the `git@` form
+      - Embedded credentials (`https://token@github.com/org/repo`): strip
+        credentials before stripping the host (i.e. treat as plain HTTPS)
+      - The result is just `org/repo`
 
-3. Match on normalized equality.
+3. Match on normalized equality (compare the bare `owner/repo` paths).
 
 ### Example
 
 Local: `git@github.com:Org/My-Repo.git`
-Normalized: `git@github.com:org/my-repo`
+
+| Step | Value |
+|------|-------|
+| 1. Lowercase | `git@github.com:org/my-repo.git` |
+| 2. Strip `.git` | `git@github.com:org/my-repo` |
+| 3. Strip trailing `/` | `git@github.com:org/my-repo` |
+| 4. Strip host (`git@github.com:`) | `org/my-repo` |
 
 API entry `url`: `https://github.com/Org/My-Repo`
-Normalized: `https://github.com/org/my-repo`
 
-These do NOT match because the scheme and transport differ (`git@` vs `https://`).
-Also strip common prefixes to compare just `org/my-repo`:
+| Step | Value |
+|------|-------|
+| 1. Lowercase | `https://github.com/org/my-repo` |
+| 2. Strip `.git` | `https://github.com/org/my-repo` |
+| 3. Strip trailing `/` | `https://github.com/org/my-repo` |
+| 4. Strip host (`https://github.com/`) | `org/my-repo` |
 
-```
-git@github.com:org/my-repo   → strip "git@github.com:" → "org/my-repo"
-https://github.com/org/my-repo → strip "https://github.com/" → "org/my-repo"
-```
-
-After stripping the host, compare the path segment (`org/my-repo`). This matches.
+Both normalize to `org/my-repo` — they match.
 
 ## No Match Fallback: `git_origin` Tag
 
@@ -70,31 +90,34 @@ inject a `git_origin` tag into `stackhawk.yml` instead:
 ```yaml
 tags:
   - name: git_origin
-    value: <normalized-url>
+    value: org/my-repo   # bare path after 4-step normalization
 ```
 
-This breadcrumb is visible in every scan from this config. Once the SCM org is
-connected in StackHawk's attack surface, the platform can automap repos to apps
-using the `git_origin` tag values. Use the normalized URL as the value.
+Use the bare `owner/repo` path (step 4 of normalization) so the platform can match
+against any transport. This breadcrumb is visible in every scan from this config.
+Once the SCM org is connected in StackHawk's attack surface, the platform can
+automap repos to apps using the `git_origin` tag values.
 
 ### Full Phase 0a Algorithm
 
 ```
 1. git remote get-url origin → LOCAL_URL
-2. Normalize LOCAL_URL → NORM_LOCAL
+   If this command fails (no git repo or no origin remote), skip Phase 0a entirely
+   and continue to Phase 0b. Repo linking is non-blocking.
+2. Apply 4-step normalization to LOCAL_URL → PATH_LOCAL (bare owner/repo path)
 3. hawkop repo list --format json → REPOS[]
 4. For each repo in REPOS[]:
-     normalize repo.url → NORM_REPO
-     strip host from both → PATH_LOCAL, PATH_REPO
+     apply 4-step normalization to repo.url → PATH_REPO
      if PATH_LOCAL == PATH_REPO:
        hawkop repo link --repo-id repo.id --app-id <APP_ID>
-       Report: "Linked app <APP_NAME> to ASM repo <REPO_NAME>"
+         (where <APP_ID> is the applicationId resolved in SKILL.md Step 1 substep 5)
+       Report: "Ensured link: app <APP_NAME> ↔ ASM repo <REPO_NAME>"
        DONE
 5. No match found:
    Inject into stackhawk.yml tags block:
      - name: git_origin
-       value: NORM_LOCAL
-   Report: "No ASM repo match for NORM_LOCAL — added git_origin tag for future automapping"
+       value: PATH_LOCAL
+   Report: "No ASM repo match for PATH_LOCAL — added git_origin tag for future automapping"
 ```
 
 ## `hawkop repo list` Output Shape

--- a/plugins/hawkscan/skills/hawkscan/references/tech-flags.md
+++ b/plugins/hawkscan/skills/hawkscan/references/tech-flags.md
@@ -1,0 +1,307 @@
+# Tech Flags Reference
+
+Auto-detect your application's technology stack and configure StackHawk tech flags accordingly.
+
+## Overview
+
+The StackHawk platform defaults **all tech flags to `true`**, which enables scanning for all rule families regardless of relevance. This creates unnecessary noise and slower scans.
+
+**Agentic best practice:** Disable all flags first, then enable only the technologies detected in the codebase. This approach:
+- Reduces false positives (no rules for tech you don't use)
+- Improves scan speed (fewer rule families to evaluate)
+- Produces more precise findings (cleaner reports)
+
+Flag names are **dot-namespaced** (e.g., `Language.Java.Spring`), **case-sensitive**, and sourced from the StackHawk API. The API is the **only source of truth** for valid flag names — never hardcode them.
+
+---
+
+## Command Reference
+
+### Fetch canonical flag list
+
+```bash
+hawkop app tech-flags get --app <APP_NAME> --format json
+```
+
+Returns a JSON object with all available flags and their current true/false state:
+
+```json
+{
+  "Language.JavaScript": false,
+  "Language.JavaScript.React": false,
+  "Language.JavaScript.NextJs": false,
+  "Language.Java": false,
+  "Language.Java.Spring": false,
+  "Db.PostgreSQL": false,
+  "Db.MySQL": false
+}
+```
+
+**Use this output to validate flag names before calling `set`.**
+
+### Disable all flags (reset to baseline)
+
+```bash
+hawkop app tech-flags disable-all --app <APP_NAME> --yes
+```
+
+Flips all flags to `false` in one operation. The `--yes` flag is **required** in non-interactive contexts (scripts, agents); omit it for interactive use (will prompt for confirmation).
+
+**Important:** If the API returns an empty flag list (no flags defined yet), skip this step and proceed directly to detection.
+
+### Enable detected flags
+
+```bash
+hawkop app tech-flags set --app <APP_NAME> \
+  Language.Java=true \
+  Language.Java.Spring=true \
+  Db.PostgreSQL=true
+```
+
+The `set` command performs a **partial update**: only the provided keys change; others stay as they are.
+
+**Value syntax:**
+- Enable: `KEY=true`, `KEY=1`, `KEY=on`, `KEY=yes`
+- Disable: `KEY=false`, `KEY=0`, `KEY=off`, `KEY=no`
+
+### Preview before committing
+
+```bash
+hawkop app tech-flags set --app <APP_NAME> \
+  Language.Java=true \
+  Language.Java.Spring=true \
+  --dry-run
+```
+
+Shows what would change without applying the update.
+
+---
+
+## Flag Name Rules
+
+- **Dot-namespaced:** `Language.Java`, `Language.Java.Spring`, `Db.PostgreSQL`
+- **Case-sensitive:** `Language.Java` ≠ `language.java`
+- **API is source of truth:** Always validate flag names via `hawkop app tech-flags get` before using them in `set` commands
+- **Parent namespace inclusion:** When enabling a child flag (e.g., `Language.Java.Spring`), also enable all parent namespaces that exist in the canonical list (e.g., `Language.Java`). The matching algorithm handles this automatically.
+
+---
+
+## Phase 0c Detection Algorithm
+
+```
+1. Call: hawkop app tech-flags get --app <APP_NAME> --format json
+   → Store result as CANONICAL_FLAGS (a dict of all valid flag keys and current states)
+   → If CANONICAL_FLAGS is empty, skip step 2 and proceed to step 3
+
+2. If CANONICAL_FLAGS is not empty:
+   Call: hawkop app tech-flags disable-all --app <APP_NAME> --yes
+   → Reset all flags to false
+
+3. Scan codebase for evidence (files, config, dependencies)
+   → Produce DETECTED_TECHS[] (list of technology identifiers: "Java", "Spring", "PostgreSQL", etc.)
+
+4. For each tech in DETECTED_TECHS:
+   a. Find all canonical keys matching the tech (case-insensitive substring match on each dot-separated segment)
+   b. From matches, select the most specific (deepest namespace wins)
+   c. If the selected flag has a parent namespace that exists in CANONICAL_FLAGS, also include parent in enabled list
+   d. If no canonical key matches, skip silently
+
+5. If any flags were selected in step 4:
+   Call: hawkop app tech-flags set --app <APP_NAME> <KEY1>=true <KEY2>=true ...
+   → Enable only the detected flags
+
+6. If no flags were detected in step 3 or no matches in step 4:
+   → Do not call set; leave flags at current state
+   → Report: "No technology evidence found; tech flags unchanged."
+
+7. Report results: list which flags were enabled and what codebase evidence triggered each
+```
+
+---
+
+## Detection Heuristics
+
+### Languages & Frameworks
+
+| Evidence | Detection | Example Flag Key |
+|----------|-----------|------------------|
+| `package.json` present | JavaScript detected | `Language.JavaScript` |
+| `package.json` contains `"react"` | React framework | `Language.JavaScript.React` |
+| `package.json` contains `"next"` | Next.js framework | `Language.JavaScript.NextJs` |
+| `package.json` contains `"vue"` | Vue.js framework | `Language.JavaScript.Vue` |
+| `package.json` contains `"angular"` | Angular framework | `Language.JavaScript.Angular` |
+| `package.json` contains `"express"` or `"fastify"` or `"koa"` | Node.js backend | `Language.JavaScript.Node` |
+| `pom.xml` or `build.gradle` present | Java detected | `Language.Java` |
+| `pom.xml` or `build.gradle` contains `spring-boot` or `spring-core` | Spring framework | `Language.Java.Spring` |
+| `requirements.txt` or `pyproject.toml` present | Python detected | `Language.Python` |
+| `requirements.txt` or `pyproject.toml` contains `django` | Django framework | `Language.Python.Django` |
+| `requirements.txt` or `pyproject.toml` contains `flask` | Flask framework | `Language.Python.Flask` |
+| `requirements.txt` or `pyproject.toml` contains `fastapi` | FastAPI framework | `Language.Python.FastAPI` |
+| `go.mod` present | Go detected | `Language.Go` |
+| `Gemfile` present | Ruby detected | `Language.Ruby` |
+| `Gemfile` contains `rails` | Rails framework | `Language.Ruby.Rails` |
+| `*.csproj` or `*.sln` present | .NET detected | `Language.Dotnet` |
+
+### Databases
+
+| Evidence | Detection | Example Flag Key |
+|----------|-----------|------------------|
+| `docker-compose.yml` contains `image: postgres:` | PostgreSQL detected | `Db.PostgreSQL` |
+| `docker-compose.yml` contains `image: mysql:` or `image: mariadb:` | MySQL/MariaDB detected | `Db.MySQL` |
+| `docker-compose.yml` contains `image: mongo:` | MongoDB detected | `Db.MongoDB` |
+| `docker-compose.yml` contains `image: redis:` | Redis detected | `Db.Redis` |
+| Connection string with `postgresql://` or `postgres://` | PostgreSQL URL found | `Db.PostgreSQL` |
+| Connection string with `mysql://` | MySQL URL found | `Db.MySQL` |
+| Connection string with `mongodb://` or `mongodb+srv://` | MongoDB URL found | `Db.MongoDB` |
+| Connection string with `sqlserver://` or `mssql` | SQL Server detected | `Db.MicrosoftSqlServer` |
+
+**How to find connection strings:** Search environment files (`.env`, `.env.local`, `.env.*.local`), config files (`config.yml`, `application.properties`, `appsettings.json`), Docker Compose services, and Kubernetes secrets/ConfigMaps.
+
+---
+
+## Matching Detected Techs to Canonical Flag Keys
+
+The detection heuristics produce friendly tech names (e.g., "Spring Boot", "PostgreSQL"). The `set` command requires exact canonical flag keys from the API.
+
+**Matching algorithm:**
+
+1. **Perform substring match (case-insensitive)** on each dot-separated segment of the canonical key.
+   - Detected tech "Spring" matches canonical keys containing "spring" (case-insensitive): `Language.Java.Spring`, `Framework.Spring`
+   - Detected tech "PostgreSQL" matches: `Db.PostgreSQL`, `Database.PostgreSQL`
+
+2. **From all matches, select the most specific** (deepest namespace wins).
+   - Detected "Spring" with matches `[Language.Java.Spring, Framework.Spring]`: choose `Language.Java.Spring` (deeper)
+   - Detected "Java" with matches `[Language.Java, Language.Java.Spring]`: choose `Language.Java.Spring` if both are in canonical; if only `Language.Java` exists, choose that
+
+3. **When enabling a child flag, also enable parents** that exist in CANONICAL_FLAGS.
+   - If enabling `Language.Java.Spring`, also check if `Language.Java` exists in CANONICAL_FLAGS and enable it too
+   - If a parent does not exist in CANONICAL_FLAGS, do not try to enable it
+
+4. **If no canonical key matches a detected tech, skip silently** and continue to the next detected tech.
+
+---
+
+## Example: Detect and Configure a Node.js + React + PostgreSQL App
+
+**Step 1: Fetch canonical flags**
+```bash
+hawkop app tech-flags get --app myapp --format json
+```
+
+```json
+{
+  "Language.JavaScript": false,
+  "Language.JavaScript.React": false,
+  "Language.JavaScript.NextJs": false,
+  "Language.JavaScript.Node": false,
+  "Language.Python": false,
+  "Language.Java": false,
+  "Db.PostgreSQL": false,
+  "Db.MySQL": false
+}
+```
+
+**Step 2: Disable all**
+```bash
+hawkop app tech-flags disable-all --app myapp --yes
+```
+
+**Step 3: Detect from codebase**
+- `package.json` → JavaScript
+- `package.json` contains `"react"` → React
+- `package.json` contains `"express"` → Node
+- `docker-compose.yml` contains `image: postgres:` → PostgreSQL
+
+DETECTED_TECHS = ["JavaScript", "React", "Node", "PostgreSQL"]
+
+**Step 4: Match to canonical keys**
+- JavaScript → `Language.JavaScript`
+- React → `Language.JavaScript.React` (more specific than `Language.JavaScript`)
+- Node → `Language.JavaScript.Node` (more specific)
+- PostgreSQL → `Db.PostgreSQL`
+
+**Parent inclusion:**
+- `Language.JavaScript.React` has parent `Language.JavaScript` (exists in canonical) → include both
+- `Language.JavaScript.Node` has parent `Language.JavaScript` (already included)
+- `Db.PostgreSQL` has no parent namespace
+
+**Flags to enable:** `Language.JavaScript=true`, `Language.JavaScript.React=true`, `Language.JavaScript.Node=true`, `Db.PostgreSQL=true`
+
+**Step 5: Enable flags**
+```bash
+hawkop app tech-flags set --app myapp \
+  Language.JavaScript=true \
+  Language.JavaScript.React=true \
+  Language.JavaScript.Node=true \
+  Db.PostgreSQL=true
+```
+
+**Step 6: Report**
+```
+Tech flags configured:
+  - Language.JavaScript: enabled (detected package.json)
+  - Language.JavaScript.React: enabled (detected react in package.json)
+  - Language.JavaScript.Node: enabled (detected express in package.json)
+  - Db.PostgreSQL: enabled (detected postgres: service in docker-compose.yml)
+```
+
+---
+
+## No Match Policy
+
+If codebase scanning finds **no evidence of any technology**, or all detected techs have no canonical key match:
+
+1. **Do not call `disable-all`** (or call it, then proceed without calling `set`)
+2. **Do not call `set`**
+3. **Report:** "No technology evidence found; tech flags unchanged."
+
+This preserves any manual flag configuration the user may have already set.
+
+---
+
+## Manual Override
+
+Users can always manually enable additional flags after tech-flag auto-configuration:
+
+```bash
+hawkop app tech-flags set --app myapp Language.Java=true
+```
+
+This is safe and encouraged if:
+- The agentic detection missed a technology (e.g., external service dependency not in codebase)
+- The user wants to enable additional rule families for defense-in-depth
+- A flag was disabled by mistake
+
+---
+
+## Troubleshooting
+
+### `hawkop app tech-flags get` returns empty
+
+No flags have been initialized yet. **Skip `disable-all` and proceed directly to detection.** After detection, call `set` to initialize the flags at the detected state.
+
+### `hawkop app tech-flags disable-all` hangs
+
+This is a known issue in `hawk` CLI 5.4.0. Upgrade to 5.5.0+, or skip the `disable-all` step and manually list all canonical keys in the `set` command (e.g., `set Language.JavaScript=false Language.JavaScript.React=false ...`).
+
+### Detection found no techs
+
+Expand heuristics:
+- Check for additional config file types (e.g., `*.gradle.kts` for Gradle Kotlin, `Pipfile` for Python/Pipenv)
+- Verify connection strings in all `.env*` files and config directories
+- Look for `node_modules/`, `.gradle/`, `target/`, `venv/`, `__pycache__/` directories as fallback evidence
+- Check inline code comments and imports (risky; use only as last resort)
+
+### A detected tech has no matching canonical key
+
+The tech exists in the codebase but the API does not have a flag for it. The detection algorithm silently skips it. Check the canonical list via `hawkop app tech-flags get` and report the gap if it's a widely-used framework.
+
+### Flags were set but some not enabled
+
+Possible causes:
+- Flag name typo or case mismatch (flag names are case-sensitive)
+- Flag does not exist in the canonical list for this StackHawk instance
+- Value syntax error (use `true`/`false`, not `True`/`False`)
+- Dry-run was used instead of actual `set` (try again without `--dry-run`)
+
+Use `hawkop app tech-flags get` after `set` to verify the final state.

--- a/plugins/hawkscan/skills/hawkscan/references/tech-flags.md
+++ b/plugins/hawkscan/skills/hawkscan/references/tech-flags.md
@@ -23,6 +23,8 @@ Flag names are **dot-namespaced** (e.g., `Language.Java.Spring`), **case-sensiti
 hawkop app tech-flags get --app <APP_NAME> --format json
 ```
 
+`--app <APP_NAME>` accepts the application name. The `hawkop` CLI also accepts `--app-id <UUID>` if you prefer to use the application ID directly.
+
 Returns a JSON object with all available flags and their current true/false state:
 
 ```json
@@ -89,32 +91,20 @@ Shows what would change without applying the update.
 ## Phase 0c Detection Algorithm
 
 ```
-1. Call: hawkop app tech-flags get --app <APP_NAME> --format json
-   → Store result as CANONICAL_FLAGS (a dict of all valid flag keys and current states)
-   → If CANONICAL_FLAGS is empty, skip step 2 and proceed to step 3
-
-2. If CANONICAL_FLAGS is not empty:
-   Call: hawkop app tech-flags disable-all --app <APP_NAME> --yes
-   → Reset all flags to false
-
-3. Scan codebase for evidence (files, config, dependencies)
-   → Produce DETECTED_TECHS[] (list of technology identifiers: "Java", "Spring", "PostgreSQL", etc.)
-
-4. For each tech in DETECTED_TECHS:
-   a. Find all canonical keys matching the tech (case-insensitive substring match on each dot-separated segment)
-   b. From matches, select the most specific (deepest namespace wins)
-   c. If the selected flag has a parent namespace that exists in CANONICAL_FLAGS, also include parent in enabled list
-   d. If no canonical key matches, skip silently
-
-5. If any flags were selected in step 4:
-   Call: hawkop app tech-flags set --app <APP_NAME> <KEY1>=true <KEY2>=true ...
-   → Enable only the detected flags
-
-6. If no flags were detected in step 3 or no matches in step 4:
-   → Do not call set; leave flags at current state
-   → Report: "No technology evidence found; tech flags unchanged."
-
-7. Report results: list which flags were enabled and what codebase evidence triggered each
+1. hawkop app tech-flags get --app <APP_NAME> --format json → CANONICAL_FLAGS{}
+   If CANONICAL_FLAGS is empty, skip to step 5 with no flags to set.
+2. Scan codebase for evidence files → DETECTED_TECHS[]
+   (Check package.json, pom.xml, go.mod, requirements.txt, docker-compose.yml, Gemfile, *.csproj/*.sln)
+3. Map DETECTED_TECHS to flag keys in CANONICAL_FLAGS → ENABLED_FLAGS[]
+   (See heuristics and matching rules below)
+4. If ENABLED_FLAGS is empty:
+     Do NOT call disable-all or set
+     Report: "No technology evidence found; tech flags unchanged."
+     DONE
+5. hawkop app tech-flags disable-all --app <APP_NAME> --yes
+   (The --yes flag is required; agents must not use the interactive form without it)
+6. hawkop app tech-flags set --app <APP_NAME> <KEY>=true ... (one entry per flag in ENABLED_FLAGS)
+7. Report: which flags were enabled and what evidence triggered each
 ```
 
 ---
@@ -161,21 +151,33 @@ Shows what would change without applying the update.
 
 ## Matching Detected Techs to Canonical Flag Keys
 
-The detection heuristics produce friendly tech names (e.g., "Spring Boot", "PostgreSQL"). The `set` command requires exact canonical flag keys from the API.
+The detection heuristics produce friendly tech names (e.g., "Spring", "PostgreSQL"). The `set` command requires exact canonical flag keys from the API.
 
-**Matching algorithm:**
+**Primary rule: use explicit heuristic mappings first.** The detection heuristics table already maps specific evidence directly to expected canonical key names (e.g., "pom.xml or build.gradle → `Language.Java`"). Use those explicit mappings directly before falling back to terminal-segment fuzzy matching.
 
-1. **Perform substring match (case-insensitive)** on each dot-separated segment of the canonical key.
-   - Detected tech "Spring" matches canonical keys containing "spring" (case-insensitive): `Language.Java.Spring`, `Framework.Spring`
-   - Detected tech "PostgreSQL" matches: `Db.PostgreSQL`, `Database.PostgreSQL`
+**Additionally:** If Phase 0a (repo linking) completed and returned `frameworkNames` from `hawkop repo list`, treat those as additional tech evidence — match each framework name against canonical flags using the terminal-segment rule below.
 
-2. **From all matches, select the most specific** (deepest namespace wins).
-   - Detected "Spring" with matches `[Language.Java.Spring, Framework.Spring]`: choose `Language.Java.Spring` (deeper)
-   - Detected "Java" with matches `[Language.Java, Language.Java.Spring]`: choose `Language.Java.Spring` if both are in canonical; if only `Language.Java` exists, choose that
+**Terminal-segment matching algorithm:**
 
-3. **When enabling a child flag, also enable parents** that exist in CANONICAL_FLAGS.
-   - If enabling `Language.Java.Spring`, also check if `Language.Java` exists in CANONICAL_FLAGS and enable it too
-   - If a parent does not exist in CANONICAL_FLAGS, do not try to enable it
+The correct rule is **terminal segment matching**: a detected technology matches a canonical key only when the technology term matches the *last* (terminal) segment of the dot-namespaced key.
+
+Example:
+- Detected "Java" → matches `Language.Java` (terminal segment is "Java") ✓
+- Detected "Java" → does NOT match `Language.Java.Spring` (terminal segment is "Spring") ✗
+- Detected "Spring" → matches `Language.Java.Spring` ✓
+
+Steps:
+
+1. For each detected technology term:
+   - Find canonical keys where the terminal segment (everything after the last `.`) matches the tech term (case-insensitive)
+   - If multiple keys match (e.g., `Language.Java` and `Framework.Java`), prefer the one under the most relevant namespace
+   - Add the matched key to ENABLED_FLAGS
+
+2. For each key added to ENABLED_FLAGS, also add all parent namespace keys that exist in CANONICAL_FLAGS:
+   - `Language.Java.Spring` is enabled → also add `Language.Java` if it exists
+   - `Language.Java` is enabled → also add `Language` if it exists
+
+3. Deduplicate ENABLED_FLAGS before calling `set`
 
 4. **If no canonical key matches a detected tech, skip silently** and continue to the next detected tech.
 
@@ -201,12 +203,7 @@ hawkop app tech-flags get --app myapp --format json
 }
 ```
 
-**Step 2: Disable all**
-```bash
-hawkop app tech-flags disable-all --app myapp --yes
-```
-
-**Step 3: Detect from codebase**
+**Step 2: Detect from codebase**
 - `package.json` → JavaScript
 - `package.json` contains `"react"` → React
 - `package.json` contains `"express"` → Node
@@ -214,20 +211,24 @@ hawkop app tech-flags disable-all --app myapp --yes
 
 DETECTED_TECHS = ["JavaScript", "React", "Node", "PostgreSQL"]
 
-**Step 4: Match to canonical keys**
-- JavaScript → `Language.JavaScript`
-- React → `Language.JavaScript.React` (more specific than `Language.JavaScript`)
-- Node → `Language.JavaScript.Node` (more specific)
-- PostgreSQL → `Db.PostgreSQL`
+**Step 3: Match to canonical keys**
+- JavaScript → `Language.JavaScript` (explicit heuristic mapping)
+- React → `Language.JavaScript.React` (terminal segment "React" matches)
+- Node → `Language.JavaScript.Node` (terminal segment "Node" matches)
+- PostgreSQL → `Db.PostgreSQL` (explicit heuristic mapping)
 
 **Parent inclusion:**
-- `Language.JavaScript.React` has parent `Language.JavaScript` (exists in canonical) → include both
-- `Language.JavaScript.Node` has parent `Language.JavaScript` (already included)
-- `Db.PostgreSQL` has no parent namespace
+- `Language.JavaScript.React` → also add `Language.JavaScript` (exists in canonical)
+- `Language.JavaScript.Node` → `Language.JavaScript` already included
+- `Db.PostgreSQL` has no parent namespace in canonical
 
-**Flags to enable:** `Language.JavaScript=true`, `Language.JavaScript.React=true`, `Language.JavaScript.Node=true`, `Db.PostgreSQL=true`
+ENABLED_FLAGS = [`Language.JavaScript`, `Language.JavaScript.React`, `Language.JavaScript.Node`, `Db.PostgreSQL`]
 
-**Step 5: Enable flags**
+**Step 4: Disable all, then enable detected flags**
+```bash
+hawkop app tech-flags disable-all --app myapp --yes
+```
+
 ```bash
 hawkop app tech-flags set --app myapp \
   Language.JavaScript=true \
@@ -236,7 +237,7 @@ hawkop app tech-flags set --app myapp \
   Db.PostgreSQL=true
 ```
 
-**Step 6: Report**
+**Step 5: Report**
 ```
 Tech flags configured:
   - Language.JavaScript: enabled (detected package.json)
@@ -251,7 +252,7 @@ Tech flags configured:
 
 If codebase scanning finds **no evidence of any technology**, or all detected techs have no canonical key match:
 
-1. **Do not call `disable-all`** (or call it, then proceed without calling `set`)
+1. **Do not call `disable-all`** — detection runs before the reset, so if no flags are found there is nothing to reset to
 2. **Do not call `set`**
 3. **Report:** "No technology evidence found; tech flags unchanged."
 
@@ -282,7 +283,7 @@ No flags have been initialized yet. **Skip `disable-all` and proceed directly to
 
 ### `hawkop app tech-flags disable-all` hangs
 
-This is a known issue in `hawk` CLI 5.4.0. Upgrade to 5.5.0+, or skip the `disable-all` step and manually list all canonical keys in the `set` command (e.g., `set Language.JavaScript=false Language.JavaScript.React=false ...`).
+If `disable-all` hangs without the `--yes` flag, it is waiting for interactive confirmation — always use `--yes` in agentic contexts. If the hang persists even with `--yes`, skip the `disable-all` step and manually list all canonical keys in the `set` command instead (e.g., `set Language.JavaScript=false Language.JavaScript.React=false ...`).
 
 ### Detection found no techs
 


### PR DESCRIPTION
## Summary

- **Phase 0** (app onboarding, runs once on new `stackhawk.yml`): three new sub-steps — repo linking to ASM (`hawkop repo link`, with `git_origin` tag fallback for unmatched remotes), agent tagging (`_STACKHAWK_AGENT: ${HAWK_AGENT:none}` written to config, detected and exported at scan time), and tech flag auto-detection (detect codebase evidence first, then disable-all + enable only matched flags via `hawkop app tech-flags`)
- **Step 4.5 upgrade**: agent can now autonomously mark `FALSE_POSITIVE` via `hawkop scan triage` with a required note; `RISK_ACCEPTED` remains human-only; stale "no triage API" text removed from SKILL.md, `platform-model.md`, and `false-positives.md`
- **Two new reference files**: `references/repo-linking.md` (URL normalization, SSH/HTTPS edge cases, git_origin fallback) and `references/tech-flags.md` (terminal-segment matching, detect-before-disable algorithm, heuristics table)

## Test Plan

- [ ] Verify `bash scripts/generate-cursor-rules.sh && git diff cursor/` produces no diff (idempotent) ✅ confirmed
- [ ] Confirm `grep -rn "platform does not expose\|agent cannot write triage\|no public API for reading or writing tech flags" plugins/hawkscan/` returns nothing ✅ confirmed
- [ ] Review Phase 0 section in `SKILL.md` appears before Step 1
- [ ] Review `references/repo-linking.md` — URL normalization algorithm, SSH URL handling, git_origin tag format
- [ ] Review `references/tech-flags.md` — detect-before-disable ordering, terminal-segment matching rule
- [ ] Confirm `_STACKHAWK_AGENT` / `${HAWK_AGENT:none}` pattern matches existing git tag conventions in `stackhawk.yml`
- [ ] Confirm agent triage rules: FALSE_POSITIVE ✅ autonomous, RISK_ACCEPTED ❌ human-only