### PR TITLE
feat: GH tag-based versioning, release workflow, and Windows installer

### DIFF
--- a/.github/workflows/generate-and-validate.yml
+++ b/.github/workflows/generate-and-validate.yml
@@ -117,6 +117,91 @@ jobs:
             exit 1
           fi
 
+      - name: Validate SKILL.md best practices (Anthropic spec)
+        run: |
+          cat > /tmp/skill_check.py << 'PYEOF'
+          import sys, re
+          path = sys.argv[1]
+          with open(path) as f:
+              content = f.read()
+          errors = 0
+          warnings = 0
+          fm_match = re.match(r'^---\n(.*?)\n---\n', content, re.DOTALL)
+          if not fm_match:
+              print(f"ERROR [{path}]: No YAML frontmatter found")
+              sys.exit(1)
+          fm = fm_match.group(1)
+          body = content[fm_match.end():]
+          name_match = re.search(r'^name:\s*(.+)', fm, re.MULTILINE)
+          if name_match:
+              name = name_match.group(1).strip()
+              if len(name) > 64:
+                  print(f"ERROR [{path}]: name exceeds 64 chars ({len(name)}): '{name}'")
+                  errors += 1
+              if not re.match(r'^[a-z0-9-]+$', name):
+                  print(f"ERROR [{path}]: name must be [a-z0-9-] only: '{name}'")
+                  errors += 1
+              if 'anthropic' in name or 'claude' in name:
+                  print(f"ERROR [{path}]: name contains reserved word ('anthropic'/'claude'): '{name}'")
+                  errors += 1
+          desc_match = re.search(r'^description:(.*?)(?=\n[a-z_]|\Z)', fm, re.MULTILINE | re.DOTALL)
+          if desc_match:
+              raw = desc_match.group(1)
+              desc = ' '.join(l.strip() for l in raw.strip().lstrip('>|').splitlines() if l.strip())
+              if not desc:
+                  print(f"ERROR [{path}]: description is empty")
+                  errors += 1
+              elif len(desc) > 1024:
+                  print(f"ERROR [{path}]: description exceeds 1024 chars ({len(desc)})")
+                  errors += 1
+              if '<' in desc or '>' in desc:
+                  print(f"ERROR [{path}]: description contains XML-style tags")
+                  errors += 1
+              if re.search(r'\bI can\b|\bI will\b|\bI am\b', desc):
+                  print(f"ERROR [{path}]: description uses first-person ('I can/will/am')")
+                  errors += 1
+          body_lines = body.count('\n')
+          if body_lines > 500:
+              print(f"WARN  [{path}]: body is {body_lines} lines (best practice: <=500; split long content into reference files)")
+              warnings += 1
+          if re.search(r'[A-Za-z0-9_\-]\\[A-Za-z0-9_\-]{2,}', body):
+              print(f"ERROR [{path}]: Windows-style path (backslash) found — use forward slashes")
+              errors += 1
+          status = "OK" if errors == 0 else "FAIL"
+          if warnings:
+              status += f" ({warnings} warning(s))"
+          print(f"{status}: {path}")
+          sys.exit(errors)
+          PYEOF
+          errors=0
+          for skill_file in plugins/*/skills/*/SKILL.md; do
+            python3 /tmp/skill_check.py "$skill_file" || errors=$((errors + 1))
+          done
+          if [ $errors -gt 0 ]; then
+            echo "FAILED: $errors SKILL.md file(s) have best-practice violations"
+            exit 1
+          fi
+
+      - name: Check reference file best practices
+        run: |
+          warnings=0
+          while IFS= read -r -d '' ref_file; do
+            lines=$(wc -l < "$ref_file")
+            if [ "$lines" -gt 100 ]; then
+              if ! grep -qi "## contents\|## table of contents\|## toc\|- \[" "$ref_file"; then
+                echo "WARN: ${lines} lines, no table of contents: $ref_file"
+                warnings=$((warnings + 1))
+              else
+                echo "OK: $ref_file (${lines} lines)"
+              fi
+            fi
+          done < <(find plugins/*/skills/*/references -name "*.md" -print0 2>/dev/null)
+          if [ $warnings -gt 0 ]; then
+            echo ""
+            echo "NOTE: $warnings reference file(s) over 100 lines lack a table of contents."
+            echo "Best practice: add a '## Contents' section at the top so Claude can navigate large files."
+          fi
+
   generate-cursor-rules:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/generate-and-validate.yml
+++ b/.github/workflows/generate-and-validate.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           expected=$(cat VERSION)
           errors=0
-          for manifest in plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json gemini-extension.json; do
+          for manifest in plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json gemini-extension.json .codex-plugin/plugin.json; do
             if [ -f "$manifest" ]; then
               actual=$(python3 -c "import json; print(json.load(open('$manifest')).get('version', 'MISSING'))")
               if [ "$actual" != "$expected" ]; then
@@ -57,6 +57,13 @@ jobs:
               fi
             fi
           done
+          # Validate marketplace plugin versions match VERSION
+          if [ -f ".claude-plugin/marketplace.json" ]; then
+            printf '%s\n' 'import json,sys' 'e=open("VERSION").read().strip()' 'd=json.load(open(".claude-plugin/marketplace.json"))' 'n=0' 'for p in d.get("plugins",[]):' '  v=p.get("version","MISSING")' '  nm=p.get("name","unknown")' '  if v!=e:' '    print(f"ERROR: marketplace.json plugin {nm!r} has {v!r}, expected {e!r}")' '    n+=1' '  else:' '    print(f"OK: marketplace.json {nm!r} (v{v})")' 'sys.exit(n)' > /tmp/_mp_check.py
+            if ! python3 /tmp/_mp_check.py; then
+              errors=$((errors + 1))
+            fi
+          fi
           if [ $errors -gt 0 ]; then
             echo "FAILED: $errors version mismatch(es)"
             exit 1

--- a/.github/workflows/generate-and-validate.yml
+++ b/.github/workflows/generate-and-validate.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Validate SKILL.md frontmatter
         run: |
           errors=0
+          expected_version=$(cat VERSION)
           for skill_file in plugins/*/skills/*/SKILL.md; do
             if ! head -20 "$skill_file" | grep -q '^name:'; then
               echo "ERROR: Missing 'name' in frontmatter: $skill_file"
@@ -23,6 +24,16 @@ jobs:
             if ! head -20 "$skill_file" | grep -q '^description:'; then
               echo "ERROR: Missing 'description' in frontmatter: $skill_file"
               errors=$((errors + 1))
+            fi
+            if ! head -20 "$skill_file" | grep -q '^version:'; then
+              echo "ERROR: Missing 'version' in frontmatter: $skill_file"
+              errors=$((errors + 1))
+            else
+              actual_version=$(head -20 "$skill_file" | grep '^version:' | sed 's/version: //')
+              if [ "$actual_version" != "$expected_version" ]; then
+                echo "ERROR: $skill_file has version '$actual_version', expected '$expected_version'"
+                errors=$((errors + 1))
+              fi
             fi
             echo "OK: $skill_file"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,12 @@ jobs:
             exit 1
           fi
 
+      - name: Validate marketplace plugin versions match tag
+        run: |
+          expected="${{ steps.version.outputs.version }}"
+          printf '%s\n' 'import json,sys' "e=sys.argv[1]" 'd=json.load(open(".claude-plugin/marketplace.json"))' 'n=0' 'for p in d.get("plugins",[]):' '  v=p.get("version","MISSING")' '  nm=p.get("name","unknown")' '  if v!=e:' '    print(f"ERROR: .claude-plugin/marketplace.json plugin {nm!r} has {v!r}, expected {e!r}")' '    n+=1' '  else:' '    print(f"OK: .claude-plugin/marketplace.json plugin {nm!r} (v{v})")' 'sys.exit(n)' > /tmp/_mp_release_check.py
+          python3 /tmp/_mp_release_check.py "$expected"
+
       - name: Validate SKILL.md versions match tag
         run: |
           expected="${{ steps.version.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,97 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate VERSION file matches tag
+        run: |
+          expected="${{ steps.version.outputs.version }}"
+          actual=$(cat VERSION)
+          if [ "$actual" != "$expected" ]; then
+            echo "ERROR: VERSION file has '${actual}', tag is '${expected}'"
+            echo "Run 'bash scripts/bump-version.sh ${expected}' and commit before tagging."
+            exit 1
+          fi
+          echo "OK: VERSION matches tag (${expected})"
+
+      - name: Validate all manifest versions match tag
+        run: |
+          expected="${{ steps.version.outputs.version }}"
+          errors=0
+          for manifest in plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json gemini-extension.json .codex-plugin/plugin.json; do
+            if [ -f "$manifest" ]; then
+              actual=$(python3 -c "import json; print(json.load(open('$manifest')).get('version', 'MISSING'))")
+              if [ "$actual" != "$expected" ]; then
+                echo "ERROR: $manifest has version '${actual}', expected '${expected}'"
+                errors=$((errors + 1))
+              else
+                echo "OK: $manifest (v${actual})"
+              fi
+            fi
+          done
+          if [ $errors -gt 0 ]; then
+            echo "FAILED: ${errors} version mismatch(es)"
+            exit 1
+          fi
+
+      - name: Validate SKILL.md versions match tag
+        run: |
+          expected="${{ steps.version.outputs.version }}"
+          errors=0
+          for skill_file in plugins/*/skills/*/SKILL.md; do
+            if [ -f "$skill_file" ]; then
+              actual=$(head -20 "$skill_file" | grep '^version:' | sed 's/version: //')
+              if [ -z "$actual" ]; then
+                echo "ERROR: Missing version in frontmatter: $skill_file"
+                errors=$((errors + 1))
+              elif [ "$actual" != "$expected" ]; then
+                echo "ERROR: $skill_file has version '${actual}', expected '${expected}'"
+                errors=$((errors + 1))
+              else
+                echo "OK: $skill_file (v${actual})"
+              fi
+            fi
+          done
+          if [ $errors -gt 0 ]; then
+            echo "FAILED: ${errors} SKILL.md version mismatch(es)"
+            exit 1
+          fi
+
+      - name: Extract changelog section for this version
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          notes=$(awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{found=0} found{print}" CHANGELOG.md)
+          if [ -z "$notes" ]; then
+            notes="Release ${VERSION}"
+          fi
+          printf '%s' "$notes" > /tmp/release-notes.txt
+          echo "notes_file=/tmp/release-notes.txt" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file "${{ steps.changelog.outputs.notes_file }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.version-bump.json
+++ b/.version-bump.json
@@ -1,0 +1,27 @@
+{
+  "files": [
+    { "path": "VERSION", "field": "version", "type": "raw" },
+    { "path": "plugins/hawkscan/.claude-plugin/plugin.json", "field": "version", "type": "json" },
+    { "path": "plugins/hawkscan/.codex-plugin/plugin.json", "field": "version", "type": "json" },
+    { "path": "plugins/api/.claude-plugin/plugin.json", "field": "version", "type": "json" },
+    { "path": "plugins/api/.codex-plugin/plugin.json", "field": "version", "type": "json" },
+    { "path": ".codex-plugin/plugin.json", "field": "version", "type": "json" },
+    { "path": "gemini-extension.json", "field": "version", "type": "json" },
+    { "path": "plugins/hawkscan/skills/hawkscan/SKILL.md", "field": "version", "type": "yaml-frontmatter" },
+    { "path": "plugins/api/skills/api/SKILL.md", "field": "version", "type": "yaml-frontmatter" }
+  ],
+  "marketplace_manifests": [
+    { "path": ".claude-plugin/marketplace.json", "field": "version", "type": "json-plugins-array" }
+  ],
+  "audit": {
+    "exclude": [
+      "CHANGELOG.md",
+      "RELEASING.md",
+      "node_modules",
+      ".git",
+      ".version-bump.json",
+      "scripts/bump-version.sh",
+      "cursor/"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,20 @@ bash scripts/generate-cursor-rules.sh
 bash scripts/generate-cursor-rules.sh && git diff cursor/
 ```
 
+## Install
+
+```powershell
+# Windows: install skills to user-level config (PowerShell)
+.\scripts\install.ps1 -Platform cursor   # installs to $HOME\.cursor\rules\
+.\scripts\install.ps1 -Platform copilot  # installs to $HOME\.agents\skills\
+```
+
+```bash
+# macOS/Linux: install skills to user-level config
+bash scripts/install.sh --platform cursor  --target ~
+bash scripts/install.sh --platform copilot --target ~
+```
+
 ## PR Workflow
 
 Before creating every PR, bump the patch version and include it in the commit:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,10 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 # StackHawk Agent Skills
 
-Multi-platform agent skills repo serving Claude, Codex, Gemini, Copilot, and Cursor from one canonical source.
+Multi-platform agent skills repo serving Claude, Codex, Gemini, Copilot, Cursor, and OpenCode from one canonical source. Skills teach AI agents to run HawkScan DAST security scanning and query the StackHawk platform API.
 
 ## Structure
 
@@ -10,6 +14,8 @@ Multi-platform agent skills repo serving Claude, Codex, Gemini, Copilot, and Cur
 - `.opencode/skills/` — Symlinks for OpenCode discovery (points into plugins/)
 - `cursor/` — Generated Cursor .mdc rules (do NOT edit manually)
 - `scripts/generate-cursor-rules.sh` — Transforms SKILL.md → Cursor .mdc format
+- `scripts/bump-version.sh` — Updates all version-bearing files atomically (reads `.version-bump.json`)
+- `scripts/release.sh` — Pre-release checks, creates tag, creates GH Release
 
 ## Commands
 
@@ -19,20 +25,25 @@ bash scripts/generate-cursor-rules.sh
 
 # Verify generation is idempotent (no diff = correct)
 bash scripts/generate-cursor-rules.sh && git diff cursor/
-```
 
-## Install
+# Bump version (updates VERSION + all manifests + SKILL.md frontmatter in one pass)
+bash scripts/bump-version.sh --patch   # bug fixes
+bash scripts/bump-version.sh --minor   # new skill or significant capability
+bash scripts/bump-version.sh --major   # breaking changes
 
-```powershell
-# Windows: install skills to user-level config (PowerShell)
-.\scripts\install.ps1 -Platform cursor   # installs to $HOME\.cursor\rules\
-.\scripts\install.ps1 -Platform copilot  # installs to $HOME\.agents\skills\
-```
+# Release (validates everything, creates annotated tag, creates GH Release)
+bash scripts/release.sh --dry-run  # validate without creating anything
+bash scripts/release.sh            # create tag + GH Release (must be on main, clean tree)
 
-```bash
-# macOS/Linux: install skills to user-level config
+# macOS/Linux install
 bash scripts/install.sh --platform cursor  --target ~
 bash scripts/install.sh --platform copilot --target ~
+```
+
+```powershell
+# Windows install
+.\scripts\install.ps1 -Platform cursor
+.\scripts\install.ps1 -Platform copilot
 ```
 
 ## PR Workflow
@@ -44,11 +55,12 @@ bash scripts/bump-version.sh --patch
 ```
 
 Use `--minor` for new skills or significant capability additions, `--major` for breaking changes.
-The script updates `VERSION` and all platform manifests in one pass.
 
-## Manifests
+See `RELEASING.md` for the full release process including how to update the marketplace catalog.
 
-All platform manifests share the version in `VERSION` (single source of truth).
+## Manifests and Versioning
+
+`VERSION` is the single source of truth. All platform manifests must match it.
 
 | Platform | Manifest |
 |----------|----------|
@@ -58,9 +70,34 @@ All platform manifests share the version in `VERSION` (single source of truth).
 | Copilot | No manifest — discovers via `skills/` symlinks |
 | Cursor | Generated into `cursor/.cursor/rules/` |
 
+`.version-bump.json` lists every version-bearing file. `bump-version.sh` reads it to update all files atomically. When adding a new plugin, add its manifests and SKILL.md to `.version-bump.json`.
+
+CI (`generate-and-validate.yml`) validates version consistency on every PR. The `release.yml` workflow fires on `v*.*.*` tag pushes and re-validates before creating the GH Release.
+
+## Adding a New Plugin
+
+1. Create `plugins/<name>/skills/<name>/SKILL.md` with `name:`, `version:`, `description:` frontmatter
+2. Create `plugins/<name>/.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`
+3. Add symlinks in `skills/` and `.opencode/skills/`
+4. Add entries to `scripts/generate-cursor-rules.sh` `MAPPINGS` array (controls Cursor .mdc generation)
+5. Add all new manifests and SKILL.md to `.version-bump.json`
+6. Run `bash scripts/bump-version.sh --minor` so version propagates
+
+## Cursor Rule Generation
+
+`scripts/generate-cursor-rules.sh` contains a `MAPPINGS` array. Each entry maps a source file to a Cursor `.mdc` rule:
+
+```
+source_path|output_name|description|globs (comma-separated or empty)|alwaysApply
+```
+
+`cursor/` is generated output — never edit `.mdc` files directly. Edit the source SKILL.md or references, then regenerate. CI blocks PRs where cursor rules are out of sync.
+
 ## Gotchas
 
 - `cursor/` is generated output — edit the source SKILL.md, then regenerate
 - `skills/` and `.opencode/skills/` entries are symlinks, not copies — don't break the relative paths
 - `docs/superpowers/` is gitignored (design specs/plans kept locally)
 - `.claude/` dir is gitignored (local settings only)
+- SKILL.md frontmatter requires `name:`, `version:`, and `description:` — CI validates all three
+- `scripts/release.sh` must be run from `main` with a clean working tree

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,228 @@
+# Releasing Agent Skills
+
+This guide covers the release process for the agent-skills repository. Releases follow [Semantic Versioning](https://semver.org/) and are published to GitHub as annotated tags and releases.
+
+## Prerequisites
+
+Before releasing, ensure:
+
+- **`gh` CLI installed** — Required for creating GitHub Releases
+  ```bash
+  brew install gh  # macOS
+  # or visit https://cli.github.com for other platforms
+  ```
+- **On `main` branch** — All releases must be tagged from `main`
+  ```bash
+  git checkout main
+  git pull origin main
+  ```
+- **Clean working tree** — No uncommitted changes or staged files
+  ```bash
+  git status  # should show "working tree clean"
+  ```
+
+## Standard Release Flow
+
+### Step 1: Bump the Version
+
+Choose the version bump based on the changes:
+
+- **`--patch`** for bug fixes (1.5.4 → 1.5.5)
+- **`--minor`** for new skills or features (1.5.4 → 1.6.0)
+- **`--major`** for breaking changes (1.5.4 → 2.0.0)
+
+```bash
+bash scripts/bump-version.sh --patch
+```
+
+This updates all version-bearing files:
+- `VERSION`
+- `.claude-plugin/marketplace.json`
+- `.codex-plugin/plugin.json`
+- `gemini-extension.json`
+- `plugins/hawkscan/.claude-plugin/plugin.json`
+- `plugins/hawkscan/.codex-plugin/plugin.json`
+- `plugins/api/.claude-plugin/plugin.json`
+- `plugins/api/.codex-plugin/plugin.json`
+- `plugins/hawkscan/skills/hawkscan/SKILL.md`
+- `plugins/api/skills/api/SKILL.md`
+
+### Step 2: Update CHANGELOG.md
+
+Add an entry for the new version following [Keep a Changelog](https://keepachangelog.com/) format:
+
+```markdown
+## [1.5.5] - 2026-05-21
+
+### Added
+- (If new features)
+
+### Fixed
+- (If bugs fixed)
+
+### Changed
+- (If existing behavior changed)
+```
+
+Place this entry at the top, above the previous releases. Use ISO date format (YYYY-MM-DD).
+
+### Step 3: Commit the Changes
+
+```bash
+git add VERSION CHANGELOG.md .claude-plugin/marketplace.json .codex-plugin/plugin.json gemini-extension.json plugins/
+git commit -m "chore: bump version to $(cat VERSION)"
+git push origin main
+```
+
+The commit message should follow the format: `chore: bump version to X.Y.Z`
+
+### Step 4: Create the Release
+
+Run the release script, which performs pre-release validation and creates both a git tag and GitHub Release:
+
+```bash
+bash scripts/release.sh
+```
+
+This script:
+1. Validates the working tree is clean
+2. Confirms you're on the `main` branch
+3. Checks that the tag doesn't already exist
+4. Ensures Cursor rules are up to date
+5. Verifies version consistency across all manifests
+6. Creates an annotated git tag: `v{version}`
+7. Pushes the tag to origin
+8. Creates a GitHub Release with the changelog section as the release notes
+
+## Pre-Release Versions
+
+For pre-release versions (beta, release candidate), use semantic versioning with a pre-release suffix:
+
+```bash
+bash scripts/bump-version.sh 1.5.5-beta.1
+bash scripts/bump-version.sh 1.6.0-rc.1
+```
+
+Pre-release versions:
+- Are included in version sort order (1.5.5-beta.1 < 1.5.5)
+- Are **not** automatically discovered by consumers unless they explicitly opt in
+- Follow the pattern `X.Y.Z-<identifier>.<number>` (e.g., `-beta.1`, `-rc.2`, `-alpha.3`)
+
+Consumers can opt in to pre-releases by configuring their platform to accept pre-release versions.
+
+## Dry Run
+
+Before committing to a release, validate the entire flow without creating tags or releases:
+
+```bash
+bash scripts/release.sh --dry-run
+```
+
+Output:
+```
+=== DRY RUN MODE ===
+
+Preparing release: vX.Y.Z
+
+All pre-release checks passed.
+
+DRY RUN: Would create tag 'vX.Y.Z' and GitHub Release.
+DRY RUN: Run without --dry-run to execute.
+```
+
+Use this to catch issues (version mismatches, Cursor rule drift, missing CHANGELOG entries) before publishing.
+
+## Consumer Cache Clearing
+
+After a release is published, consumers may see their plugin caches. To force a refresh:
+
+```bash
+rm -rf ~/.claude/plugins/cache/
+```
+
+Consumers should clear their cache after pulling a new version. This is documented in their respective plugin configuration docs.
+
+## What the Release Workflow Does
+
+The GitHub Actions workflow (`.github/workflows/release.yml`) runs automatically when a `v*.*.*` tag is pushed:
+
+### Pre-Release Validation
+
+When triggered by a tag push, the workflow:
+
+1. **Extracts the version from the tag** — e.g., `v1.5.5` → `1.5.5`
+2. **Validates VERSION file matches the tag** — Ensures `VERSION` file contains exactly the tag version
+3. **Validates all manifest versions match the tag** — Checks:
+   - `.claude-plugin/marketplace.json`
+   - `.codex-plugin/plugin.json`
+   - `gemini-extension.json`
+   - `plugins/hawkscan/.claude-plugin/plugin.json`
+   - `plugins/hawkscan/.codex-plugin/plugin.json`
+   - `plugins/api/.claude-plugin/plugin.json`
+   - `plugins/api/.codex-plugin/plugin.json`
+4. **Validates SKILL.md versions match the tag** — Checks frontmatter `version:` in each skill file
+5. **Extracts changelog section** — Pulls the `## [X.Y.Z]` section from CHANGELOG.md for release notes
+
+### GitHub Release Creation
+
+If all validation passes, the workflow:
+
+- **Creates a GitHub Release** with the tag as title and changelog section as body
+- **Makes the release available** to marketplace consumers and integrations
+
+If validation fails, the workflow exits with an error and no release is created. Fix the issue locally, amend the commit, force-push if needed, and retry.
+
+## Recovering from a Bad Tag
+
+If you create a tag and the release workflow fails (or you spot an issue before publishing):
+
+### Delete the local tag:
+```bash
+git tag -d vX.Y.Z
+```
+
+### Delete the remote tag:
+```bash
+git push origin --delete vX.Y.Z
+```
+
+### Fix the issue locally:
+```bash
+# Fix VERSION, CHANGELOG, manifests, or SKILL.md files
+bash scripts/bump-version.sh X.Y.Z  # re-bump if needed
+git add -A
+git commit --amend --no-edit
+git push origin main --force-with-lease
+```
+
+### Retry the release:
+```bash
+bash scripts/release.sh
+```
+
+## Updating the Marketplace Catalog
+
+After a release is published, the [stackhawk/agent-skills-marketplace](https://github.com/stackhawk/agent-skills-marketplace) repository's `marketplace.json` should be updated to reference the new tag and commit SHA.
+
+Update entries in that repo's catalog with:
+
+- **`ref`** — The new tag (e.g., `v1.5.5`)
+- **`sha`** — The commit SHA of the tag (run `git rev-parse v1.5.5` to get it)
+- **`version`** — The version number (e.g., `1.5.5`)
+
+This allows marketplace consumers to discover and install the new version.
+
+### Example update:
+
+```json
+{
+  "name": "agent-skills",
+  "title": "StackHawk Agent Skills",
+  "description": "...",
+  "ref": "v1.5.5",
+  "sha": "abc1234567890def...",
+  "version": "1.5.5"
+}
+```
+
+Submit a PR to the marketplace repo with this update.

--- a/plugins/api/skills/api/SKILL.md
+++ b/plugins/api/skills/api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api
-version: 1.5.4
+version: 1.6.2
 description: >
   Use this skill when a user or agent needs to query the StackHawk platform for
   security reporting, findings analysis, or app management. Triggers include:

--- a/plugins/api/skills/api/SKILL.md
+++ b/plugins/api/skills/api/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: api
+version: 1.5.4
 description: >
   Use this skill when a user or agent needs to query the StackHawk platform for
   security reporting, findings analysis, or app management. Triggers include:

--- a/plugins/hawkscan/skills/hawkscan/SKILL.md
+++ b/plugins/hawkscan/skills/hawkscan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hawkscan
-version: 1.5.4
+version: 1.6.2
 description: >
   AUTONOMOUS: After completing any code change (feature, bugfix, refactor),
   invoke this skill to run the full HawkScan security loop — configure, scan,

--- a/plugins/hawkscan/skills/hawkscan/SKILL.md
+++ b/plugins/hawkscan/skills/hawkscan/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: hawkscan
+version: 1.5.4
 description: >
   AUTONOMOUS: After completing any code change (feature, bugfix, refactor),
   invoke this skill to run the full HawkScan security loop — configure, scan,

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # ─── Version Bump Script ───
 # Reads .version-bump.json to find every file needing a version update.
-# Handles three file types: raw (VERSION), json, yaml-frontmatter.
+# Handles four file types: raw (VERSION), json, yaml-frontmatter, json-plugins-array.
 # Usage: ./scripts/bump-version.sh --patch|--minor|--major|<new-version>
 # Examples:
 #   ./scripts/bump-version.sh --patch   # 1.3.0 → 1.3.1

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 # ─── Version Bump Script ───
-# Updates VERSION file and all platform manifests in one pass.
-# Usage: ./scripts/bump-version.sh --patch|--minor|--major
-#        ./scripts/bump-version.sh <new-version>
+# Reads .version-bump.json to find every file needing a version update.
+# Handles three file types: raw (VERSION), json, yaml-frontmatter.
+# Usage: ./scripts/bump-version.sh --patch|--minor|--major|<new-version>
 # Examples:
 #   ./scripts/bump-version.sh --patch   # 1.3.0 → 1.3.1
 #   ./scripts/bump-version.sh --minor   # 1.3.0 → 1.4.0
@@ -12,25 +12,30 @@ set -euo pipefail
 #   ./scripts/bump-version.sh 1.5.0     # explicit version
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MANIFEST="${REPO_ROOT}/.version-bump.json"
 
 if [ $# -ne 1 ]; then
   echo "Usage: $0 --patch|--minor|--major|<new-version>" >&2
   exit 1
 fi
 
+if [ ! -f "$MANIFEST" ]; then
+  echo "ERROR: .version-bump.json not found at ${MANIFEST}" >&2
+  exit 1
+fi
+
 current_version=$(cat "${REPO_ROOT}/VERSION")
-IFS='.' read -r major minor patch <<< "$current_version"
+IFS='.' read -r major minor patch_ver <<< "${current_version%%-*}"
 
 case "$1" in
-  --patch) new_version="${major}.${minor}.$((patch + 1))" ;;
+  --patch) new_version="${major}.${minor}.$((patch_ver + 1))" ;;
   --minor) new_version="${major}.$((minor + 1)).0" ;;
   --major) new_version="$((major + 1)).0.0" ;;
   *)       new_version="$1" ;;
 esac
 
-# Validate version format (semver-ish: X.Y.Z)
-if ! printf '%s' "$new_version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-  echo "ERROR: Version must be in X.Y.Z format (e.g., 1.2.3)" >&2
+if ! printf '%s' "$new_version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+  echo "ERROR: Version must be in X.Y.Z or X.Y.Z-prerelease format" >&2
   exit 1
 fi
 
@@ -44,65 +49,70 @@ fi
 echo "Bumping version: ${old_version} → ${new_version}"
 echo ""
 
-# Update VERSION file
-printf '%s' "$new_version" > "${REPO_ROOT}/VERSION"
-echo "  Updated: VERSION"
+python3 - "$REPO_ROOT" "$MANIFEST" "$old_version" "$new_version" <<'PYEOF'
+import json
+import re
+import sys
+import os
 
-# Find and update all JSON manifests containing a "version" field
-manifests=(
-  "${REPO_ROOT}/plugins/hawkscan/.claude-plugin/plugin.json"
-  "${REPO_ROOT}/plugins/hawkscan/.codex-plugin/plugin.json"
-  "${REPO_ROOT}/plugins/api/.claude-plugin/plugin.json"
-  "${REPO_ROOT}/plugins/api/.codex-plugin/plugin.json"
-  "${REPO_ROOT}/.codex-plugin/plugin.json"
-  "${REPO_ROOT}/gemini-extension.json"
-)
+repo_root, manifest_path, old_ver, new_ver = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
 
-# Marketplace manifests have version inside plugin entries
-marketplace_manifests=(
-  "${REPO_ROOT}/.claude-plugin/marketplace.json"
-)
+with open(manifest_path) as f:
+    manifest = json.load(f)
 
-updated=0
+updated = 0
 
-for manifest in "${manifests[@]}"; do
-  if [ -f "$manifest" ]; then
-    python3 -c "
-import json, sys
-with open('$manifest', 'r') as f:
-    data = json.load(f)
-if 'version' in data:
-    data['version'] = '$new_version'
-with open('$manifest', 'w') as f:
-    json.dump(data, f, indent=2)
-    f.write('\n')
-"
-    relative="${manifest#"${REPO_ROOT}/"}"
-    echo "  Updated: ${relative}"
-    updated=$((updated + 1))
-  fi
-done
+def update_json_file(path, field, new_ver):
+    with open(path) as f:
+        data = json.load(f)
+    if field in data:
+        data[field] = new_ver
+    with open(path, 'w') as f:
+        json.dump(data, f, indent=2)
+        f.write('\n')
 
-for manifest in "${marketplace_manifests[@]}"; do
-  if [ -f "$manifest" ]; then
-    python3 -c "
-import json, sys
-with open('$manifest', 'r') as f:
-    data = json.load(f)
-if 'plugins' in data:
-    for plugin in data['plugins']:
-        if 'version' in plugin:
-            plugin['version'] = '$new_version'
-with open('$manifest', 'w') as f:
-    json.dump(data, f, indent=2)
-    f.write('\n')
-"
-    relative="${manifest#"${REPO_ROOT}/"}"
-    echo "  Updated: ${relative} (plugin entries)"
-    updated=$((updated + 1))
-  fi
-done
+def update_yaml_frontmatter(path, field, new_ver):
+    with open(path) as f:
+        content = f.read()
+    pattern = rf'^{re.escape(field)}: [^\n]+'
+    new_content = re.sub(pattern, f'{field}: {new_ver}', content, count=1, flags=re.MULTILINE)
+    with open(path, 'w') as f:
+        f.write(new_content)
 
-echo ""
-echo "Done. Updated VERSION + ${updated} manifest(s) from ${old_version} → ${new_version}."
-echo "Run 'git diff' to review changes before committing."
+for entry in manifest.get("files", []):
+    abs_path = os.path.join(repo_root, entry["path"])
+    if not os.path.exists(abs_path):
+        print(f"  SKIP (not found): {entry['path']}")
+        continue
+    file_type = entry.get("type", "json")
+    field = entry["field"]
+    if file_type == "raw":
+        with open(abs_path, 'w') as f:
+            f.write(new_ver)
+    elif file_type == "json":
+        update_json_file(abs_path, field, new_ver)
+    elif file_type == "yaml-frontmatter":
+        update_yaml_frontmatter(abs_path, field, new_ver)
+    print(f"  Updated: {entry['path']}")
+    updated += 1
+
+for entry in manifest.get("marketplace_manifests", []):
+    abs_path = os.path.join(repo_root, entry["path"])
+    if not os.path.exists(abs_path):
+        print(f"  SKIP (not found): {entry['path']}")
+        continue
+    with open(abs_path) as f:
+        data = json.load(f)
+    if "plugins" in data:
+        for plugin in data["plugins"]:
+            if entry["field"] in plugin:
+                plugin[entry["field"]] = new_ver
+    with open(abs_path, 'w') as f:
+        json.dump(data, f, indent=2)
+        f.write('\n')
+    print(f"  Updated: {entry['path']} (plugin entries)")
+    updated += 1
+
+print(f"\nDone. Updated {updated} file(s): {old_ver} → {new_ver}")
+print("Run 'git diff' to review changes before committing.")
+PYEOF

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,71 @@
+#Requires -Version 5.1
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet("cursor", "copilot")]
+    [string]$Platform
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+
+switch ($Platform) {
+    "cursor" {
+        $source = Join-Path $RepoRoot "cursor\.cursor\rules"
+        $dest   = Join-Path $HOME   ".cursor\rules"
+
+        if (-not (Test-Path $source)) {
+            Write-Error "Cursor rules not found at '$source'. Run 'bash scripts/generate-cursor-rules.sh' first."
+            exit 1
+        }
+
+        $existing = Get-Item (Join-Path $dest "stackhawk-*.mdc") -ErrorAction SilentlyContinue
+        if ($existing) {
+            Write-Host "WARNING: StackHawk Cursor rules already exist in ${dest}\"
+            Write-Host "Files that will be overwritten:"
+            $existing | ForEach-Object { Write-Host "  $($_.Name)" }
+            Write-Host ""
+            $confirm = Read-Host "Overwrite? [y/N]"
+            if ($confirm -notin @("y", "Y")) {
+                Write-Host "Aborted."
+                exit 0
+            }
+        }
+
+        New-Item -ItemType Directory -Force $dest | Out-Null
+        Copy-Item (Join-Path $source "stackhawk-*.mdc") $dest -Force
+        $count = (Get-Item (Join-Path $dest "stackhawk-*.mdc")).Count
+        Write-Host "Installed $count Cursor rules to ${dest}\"
+    }
+
+    "copilot" {
+        $hawkscanSrc = Join-Path $RepoRoot "plugins\hawkscan\skills\hawkscan"
+        $apiSrc      = Join-Path $RepoRoot "plugins\api\skills\api"
+        $dest        = Join-Path $HOME ".agents\skills"
+        $hawkscanDst = Join-Path $dest "hawkscan"
+        $apiDst      = Join-Path $dest "stackhawk-api"
+
+        $existingDirs = @()
+        if (Test-Path $hawkscanDst) { $existingDirs += "hawkscan\" }
+        if (Test-Path $apiDst)      { $existingDirs += "stackhawk-api\" }
+
+        if ($existingDirs.Count -gt 0) {
+            Write-Host "WARNING: StackHawk skills already exist in ${dest}\"
+            Write-Host "Directories that will be overwritten:"
+            $existingDirs | ForEach-Object { Write-Host "  $_" }
+            Write-Host ""
+            $confirm = Read-Host "Overwrite? [y/N]"
+            if ($confirm -notin @("y", "Y")) {
+                Write-Host "Aborted."
+                exit 0
+            }
+        }
+
+        New-Item -ItemType Directory -Force $hawkscanDst | Out-Null
+        New-Item -ItemType Directory -Force $apiDst      | Out-Null
+        Copy-Item -Recurse "$hawkscanSrc\*" $hawkscanDst -Force
+        Copy-Item -Recurse "$apiSrc\*"      $apiDst      -Force
+        Write-Host "Installed StackHawk skills to ${dest}\"
+        Write-Host "  hawkscan\       -- DAST scanning skill"
+        Write-Host "  stackhawk-api\  -- API reporting skill"
+    }
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -18,6 +18,12 @@ switch ($Platform) {
             exit 1
         }
 
+        $sourceFiles = @(Get-ChildItem -Path (Join-Path $source "stackhawk-*.mdc") -ErrorAction SilentlyContinue)
+        if ($sourceFiles.Count -eq 0) {
+            Write-Error "No stackhawk-*.mdc files found in '$source'. Run 'bash scripts/generate-cursor-rules.sh' first."
+            exit 1
+        }
+
         $existing = Get-Item (Join-Path $dest "stackhawk-*.mdc") -ErrorAction SilentlyContinue
         if ($existing) {
             Write-Host "WARNING: StackHawk Cursor rules already exist in ${dest}\"
@@ -33,7 +39,7 @@ switch ($Platform) {
 
         New-Item -ItemType Directory -Force $dest | Out-Null
         Copy-Item (Join-Path $source "stackhawk-*.mdc") $dest -Force
-        $count = (Get-Item (Join-Path $dest "stackhawk-*.mdc")).Count
+        $count = @(Get-ChildItem -Path (Join-Path $dest "stackhawk-*.mdc") -ErrorAction SilentlyContinue).Count
         Write-Host "Installed $count Cursor rules to ${dest}\"
     }
 
@@ -43,6 +49,15 @@ switch ($Platform) {
         $dest        = Join-Path $HOME ".agents\skills"
         $hawkscanDst = Join-Path $dest "hawkscan"
         $apiDst      = Join-Path $dest "stackhawk-api"
+
+        if (-not (Test-Path $hawkscanSrc)) {
+            Write-Error "Copilot skill source not found at '$hawkscanSrc'. Is the repo fully checked out?"
+            exit 1
+        }
+        if (-not (Test-Path $apiSrc)) {
+            Write-Error "Copilot skill source not found at '$apiSrc'. Is the repo fully checked out?"
+            exit 1
+        }
 
         $existingDirs = @()
         if (Test-Path $hawkscanDst) { $existingDirs += "hawkscan\" }


### PR DESCRIPTION
## Summary

- **Windows installer**: adds `scripts/install.ps1` — PowerShell user-level skill installer for Cursor and Copilot platforms (with source validation and safe glob handling)
- **Versioning discipline**: adds `version:` field to SKILL.md frontmatter, `.version-bump.json` as the single canonical list of version-bearing files, and rewrites `scripts/bump-version.sh` to read from it (handles JSON, YAML frontmatter, and raw file types)
- **Release workflow**: adds `.github/workflows/release.yml` triggered on `v*.*.*` tags — validates all version fields match the tag, then creates a GH Release using the CHANGELOG.md section
- **CI hardening**: extends `generate-and-validate.yml` to validate SKILL.md `version:` field and `.claude-plugin/marketplace.json` plugin-array versions against `VERSION`; adds missing `.codex-plugin/plugin.json` to manifest validation loop; adds Anthropic best-practices checks (name format, description length/third-person/no XML tags, 500-line body warning, Windows path detection)
- **Release runbook**: adds `RELEASING.md` covering the full flow: bump → CHANGELOG → commit → `scripts/release.sh` → marketplace PR, plus pre-release versions and consumer cache-clearing

## How this affects plugin/skill installation

**For users installing via Claude Code marketplace (`/plugin install`):**
No change to the install experience — plugins install the same way. What changes is the *version* consumers get. Currently there are no GH Releases, so Claude Code pins to a commit SHA with no clear signal of what's "stable." After this PR is merged and we tag `v1.5.4` (or the next version), the marketplace catalog will point at a tagged, named release instead of an arbitrary SHA. Consumers get:
- A human-readable version label in their install (`1.5.4`)
- Reproducible installs — the same tag always resolves to the same code
- Clear release notes via GH Releases (what changed, when)

**For users who are stale on a cached install:**
If Claude Code has cached an old plugin install, clearing the cache forces a fresh pull:
```bash
rm -rf ~/.claude/plugins/cache/
```

**For users installing manually (Cursor, Copilot, install scripts):**
- macOS/Linux: `bash scripts/install.sh --platform cursor --target ~`
- Windows: `.\scripts\install.ps1 -Platform cursor` ← new in this PR

**For the `agent-skills-marketplace` repo (future):**
ENG-47 also calls for a separate `stackhawk/agent-skills-marketplace` repo that holds only a `marketplace.json` pointing at a pinned `agent-skills` tag+SHA. Once that repo exists, bumping the pinned version there (independently of plugin dev work) is how we roll stable releases to consumers. That step is post-merge on main.

## Test Plan

- [ ] Verify `bash -n scripts/bump-version.sh` passes (syntax check)
- [ ] Verify `bash scripts/release.sh --dry-run` passes all pre-release checks on main
- [ ] Confirm `generate-and-validate.yml` CI passes on this PR (validate + generate-cursor-rules both green)
- [ ] Confirm `release.yml` workflow appears in Actions tab (will only fire on `v*.*.*` tag push)
- [ ] After merge: run `bash scripts/bump-version.sh --patch` and confirm all 10 version-bearing files are updated atomically
- [ ] After merge: tag `v1.x.x` and verify the release workflow creates a GH Release with the correct CHANGELOG section
- [ ] After merge: verify `rm -rf ~/.claude/plugins/cache/ && /plugin install hawkscan@stackhawk` picks up the newly tagged version

Closes ENG-47