### PR TITLE
feat: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,9 +83,8 @@ jobs:
             echo "tag=${{ steps.tag_version.outputs.tag }}" >> "$GITHUB_OUTPUT"
           fi
 
-      # ── Skip remaining steps on dry run ───────────────────────────────────
+      # ── Validation runs on all triggers including dry run ─────────────────
       - name: Validate VERSION file matches tag
-        if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)"
         run: |
           expected="${{ steps.version.outputs.version }}"
           actual=$(cat VERSION)
@@ -97,7 +96,6 @@ jobs:
           echo "OK: VERSION matches tag (${expected})"
 
       - name: Validate all manifest versions match tag
-        if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)"
         run: |
           expected="${{ steps.version.outputs.version }}"
           errors=0
@@ -118,14 +116,12 @@ jobs:
           fi
 
       - name: Validate marketplace plugin versions match tag
-        if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)"
         run: |
           expected="${{ steps.version.outputs.version }}"
           printf '%s\n' 'import json,sys' "e=sys.argv[1]" 'd=json.load(open(".claude-plugin/marketplace.json"))' 'n=0' 'for p in d.get("plugins",[]):' '  v=p.get("version","MISSING")' '  nm=p.get("name","unknown")' '  if v!=e:' '    print(f"ERROR: .claude-plugin/marketplace.json plugin {nm!r} has {v!r}, expected {e!r}")' '    n+=1' '  else:' '    print(f"OK: .claude-plugin/marketplace.json plugin {nm!r} (v{v})")' 'sys.exit(n)' > /tmp/_mp_release_check.py
           python3 /tmp/_mp_release_check.py "$expected"
 
       - name: Validate SKILL.md versions match tag
-        if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)"
         run: |
           expected="${{ steps.version.outputs.version }}"
           errors=0
@@ -149,7 +145,6 @@ jobs:
           fi
 
       - name: Extract changelog section for this version
-        if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)"
         id: changelog
         run: |
           VERSION="${{ steps.version.outputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,13 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Validate only — skip tag and release creation'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -13,27 +20,84 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
 
-      - name: Extract version from tag
-        id: version
+      # ── Manual trigger: validate pre-conditions, create annotated tag ──────
+      - name: Create release tag (workflow_dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        id: create_tag
+        run: |
+          version=$(cat VERSION)
+          tag="v${version}"
+
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "ERROR: Release must be triggered from the main branch (got '$GITHUB_REF')"
+            exit 1
+          fi
+
+          if git rev-parse --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "ERROR: Tag '${tag}' already exists. Bump VERSION first."
+            exit 1
+          fi
+
+          bash scripts/generate-cursor-rules.sh >/dev/null
+          if ! git diff --quiet cursor/; then
+            echo "ERROR: Cursor rules are out of date. Run 'bash scripts/generate-cursor-rules.sh' locally and commit."
+            exit 1
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "DRY RUN: all pre-release checks passed. Would create tag '${tag}'."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${tag}" -m "${tag}: Release"
+          git push origin "${tag}"
+          echo "Created and pushed tag: ${tag}"
+
+      # ── Tag push trigger: extract version from ref ─────────────────────────
+      - name: Extract version from tag (push trigger)
+        if: github.event_name == 'push'
+        id: tag_version
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           VERSION="${TAG#v}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
+      # ── Shared: resolve version/tag for downstream steps ──────────────────
+      - name: Resolve version and tag
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ steps.create_tag.outputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "tag=${{ steps.create_tag.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ steps.tag_version.outputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "tag=${{ steps.tag_version.outputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── Skip remaining steps on dry run ───────────────────────────────────
       - name: Validate VERSION file matches tag
+        if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)"
         run: |
           expected="${{ steps.version.outputs.version }}"
           actual=$(cat VERSION)
           if [ "$actual" != "$expected" ]; then
             echo "ERROR: VERSION file has '${actual}', tag is '${expected}'"
-            echo "Run 'bash scripts/bump-version.sh ${expected}' and commit before tagging."
+            echo "Run 'bash scripts/bump-version.sh ${expected}' and commit before releasing."
             exit 1
           fi
           echo "OK: VERSION matches tag (${expected})"
 
       - name: Validate all manifest versions match tag
+        if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)"
         run: |
           expected="${{ steps.version.outputs.version }}"
           errors=0
@@ -54,12 +118,14 @@ jobs:
           fi
 
       - name: Validate marketplace plugin versions match tag
+        if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)"
         run: |
           expected="${{ steps.version.outputs.version }}"
           printf '%s\n' 'import json,sys' "e=sys.argv[1]" 'd=json.load(open(".claude-plugin/marketplace.json"))' 'n=0' 'for p in d.get("plugins",[]):' '  v=p.get("version","MISSING")' '  nm=p.get("name","unknown")' '  if v!=e:' '    print(f"ERROR: .claude-plugin/marketplace.json plugin {nm!r} has {v!r}, expected {e!r}")' '    n+=1' '  else:' '    print(f"OK: .claude-plugin/marketplace.json plugin {nm!r} (v{v})")' 'sys.exit(n)' > /tmp/_mp_release_check.py
           python3 /tmp/_mp_release_check.py "$expected"
 
       - name: Validate SKILL.md versions match tag
+        if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)"
         run: |
           expected="${{ steps.version.outputs.version }}"
           errors=0
@@ -83,6 +149,7 @@ jobs:
           fi
 
       - name: Extract changelog section for this version
+        if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)"
         id: changelog
         run: |
           VERSION="${{ steps.version.outputs.version }}"
@@ -94,6 +161,7 @@ jobs:
           echo "notes_file=/tmp/release-notes.txt" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
+        if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)"
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           gh release create "$TAG" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.2] - 2026-05-21
+
+### Added
+- Windows PowerShell installer (`scripts/install.ps1`) for user-level skill installation on Cursor and Copilot
+- GH tag-based release workflow (`.github/workflows/release.yml`) — validates all version fields match tag, creates GH Release from CHANGELOG section
+- `.version-bump.json` — canonical manifest of all version-bearing files; `bump-version.sh` now reads from it
+- `RELEASING.md` — full release runbook: bump → CHANGELOG → tag → GH Release → marketplace PR
+- `version:` field in SKILL.md frontmatter for all plugins
+- CI best-practices checks: SKILL.md name/description format, 500-line body warning, Windows path detection (Anthropic spec)
+- CI marketplace version validation: `.claude-plugin/marketplace.json` plugin-array versions checked against VERSION
+- hawk v5.5.11+ preflight check with hard stop and upgrade instructions
+- One-scan-at-a-time guard and rescan-as-default in hawkscan skill
+- High-iteration findings reference (CSP, CORS, Auth, Headers)
+- `hawk config show` recipe fetching replaces inline auth config (requires hawk v5.5.11+)
+
+### Fixed
+- `bump-version.sh` now handles JSON, YAML frontmatter, and raw file types atomically
+- Root `.codex-plugin/plugin.json` added to CI manifest validation loop (was missing)
+- Source validation and safe glob count in `install.ps1`
+
+---
+
 ## [1.4.0] - 2026-05-01
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds a **manual release trigger** to \`release.yml\` via \`workflow_dispatch\` so releases can be kicked off from the GitHub Actions UI without needing local access
- Adds a **dry-run input** — validate all pre-conditions without creating a tag or release
- Adds \`CHANGELOG\` entry for v1.6.2

## How to release

1. Go to **Actions → Release → Run workflow** on \`main\`
2. Leave dry-run unchecked (or check it to validate without releasing)
3. Click **Run workflow**

The workflow will:
- Confirm branch is \`main\` and tag doesn't already exist
- Check cursor rules are current
- Create annotated tag \`vX.Y.Z\` and push it
- Validate all manifest + SKILL.md versions match the tag
- Create the GitHub Release from the matching CHANGELOG section

## Triggers

| Trigger | Behavior |
|---------|----------|
| \`workflow_dispatch\` (dry_run=false) | Full release: validate → tag → release |
| \`workflow_dispatch\` (dry_run=true) | Validate only, no tag or release created |
| \`push: tags: v*.*.*\` | Backward compat — validates + creates release when tag is pushed manually (e.g. via local \`release.sh\`) |

## Test Plan

- [ ] Run workflow with **dry_run=true** on main — all checks pass, no tag created
- [ ] Run workflow with **dry_run=false** — tag \`v1.6.2\` created, GH Release appears with correct CHANGELOG notes
- [ ] Confirm tag-push path still works (push a tag manually, release is created)