### PR TITLE
feat: auto-tag on every merge, release from specific tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,14 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
   workflow_dispatch:
     inputs:
+      tag:
+        description: 'Tag to release (e.g. v1.6.2) — must already exist'
+        required: true
+        type: string
       dry_run:
-        description: 'Validate only — skip tag and release creation'
+        description: 'Validate only — skip release creation'
         required: false
         type: boolean
         default: false
@@ -23,90 +24,49 @@ jobs:
         with:
           fetch-depth: 0
 
-      # ── Manual trigger: validate pre-conditions, create annotated tag ──────
-      - name: Create release tag (workflow_dispatch)
-        if: github.event_name == 'workflow_dispatch'
-        id: create_tag
-        run: |
-          version=$(cat VERSION)
-          tag="v${version}"
-
-          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
-            echo "ERROR: Release must be triggered from the main branch (got '$GITHUB_REF')"
-            exit 1
-          fi
-
-          if git rev-parse --verify "refs/tags/${tag}" >/dev/null 2>&1; then
-            echo "ERROR: Tag '${tag}' already exists. Bump VERSION first."
-            exit 1
-          fi
-
-          bash scripts/generate-cursor-rules.sh >/dev/null
-          if ! git diff --quiet cursor/; then
-            echo "ERROR: Cursor rules are out of date. Run 'bash scripts/generate-cursor-rules.sh' locally and commit."
-            exit 1
-          fi
-
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            echo "DRY RUN: all pre-release checks passed. Would create tag '${tag}'."
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${tag}" -m "${tag}: Release"
-          git push origin "${tag}"
-          echo "Created and pushed tag: ${tag}"
-
-      # ── Tag push trigger: extract version from ref ─────────────────────────
-      - name: Extract version from tag (push trigger)
-        if: github.event_name == 'push'
-        id: tag_version
-        run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          VERSION="${TAG#v}"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-      # ── Shared: resolve version/tag for downstream steps ──────────────────
-      - name: Resolve version and tag
+      - name: Resolve version from tag input
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ steps.create_tag.outputs.version }}" >> "$GITHUB_OUTPUT"
-            echo "tag=${{ steps.create_tag.outputs.tag }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "version=${{ steps.tag_version.outputs.version }}" >> "$GITHUB_OUTPUT"
-            echo "tag=${{ steps.tag_version.outputs.tag }}" >> "$GITHUB_OUTPUT"
-          fi
+          tag="${{ inputs.tag }}"
+          version="${tag#v}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
-      # ── Validation runs on all triggers including dry run ─────────────────
+      - name: Validate tag exists
+        run: |
+          tag="${{ steps.version.outputs.tag }}"
+          if ! git rev-parse --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "ERROR: Tag '${tag}' does not exist"
+            echo "Tags are created automatically on every merge to main."
+            echo "Available recent tags:"
+            git tag --sort=-version:refname | head -10
+            exit 1
+          fi
+          echo "OK: tag '${tag}' exists at $(git rev-list -n 1 ${tag})"
+
       - name: Validate VERSION file matches tag
         run: |
           expected="${{ steps.version.outputs.version }}"
-          actual=$(cat VERSION)
+          actual=$(git show "${{ steps.version.outputs.tag }}:VERSION")
           if [ "$actual" != "$expected" ]; then
-            echo "ERROR: VERSION file has '${actual}', tag is '${expected}'"
-            echo "Run 'bash scripts/bump-version.sh ${expected}' and commit before releasing."
+            echo "ERROR: VERSION at tag '${{ steps.version.outputs.tag }}' is '${actual}', expected '${expected}'"
             exit 1
           fi
-          echo "OK: VERSION matches tag (${expected})"
+          echo "OK: VERSION at tag is ${actual}"
 
       - name: Validate all manifest versions match tag
         run: |
           expected="${{ steps.version.outputs.version }}"
+          tag="${{ steps.version.outputs.tag }}"
           errors=0
-          for manifest in plugins/*/.claude-plugin/plugin.json plugins/*/.codex-plugin/plugin.json gemini-extension.json .codex-plugin/plugin.json; do
-            if [ -f "$manifest" ]; then
-              actual=$(python3 -c "import json; print(json.load(open('$manifest')).get('version', 'MISSING'))")
+          for manifest in plugins/hawkscan/.claude-plugin/plugin.json plugins/api/.claude-plugin/plugin.json plugins/hawkscan/.codex-plugin/plugin.json plugins/api/.codex-plugin/plugin.json gemini-extension.json .codex-plugin/plugin.json; do
+            if git show "${tag}:${manifest}" >/dev/null 2>&1; then
+              actual=$(git show "${tag}:${manifest}" | python3 -c "import json,sys; print(json.load(sys.stdin).get('version','MISSING'))")
               if [ "$actual" != "$expected" ]; then
-                echo "ERROR: $manifest has version '${actual}', expected '${expected}'"
+                echo "ERROR: ${manifest} has version '${actual}', expected '${expected}'"
                 errors=$((errors + 1))
               else
-                echo "OK: $manifest (v${actual})"
+                echo "OK: ${manifest} (v${actual})"
               fi
             fi
           done
@@ -118,25 +78,38 @@ jobs:
       - name: Validate marketplace plugin versions match tag
         run: |
           expected="${{ steps.version.outputs.version }}"
-          printf '%s\n' 'import json,sys' "e=sys.argv[1]" 'd=json.load(open(".claude-plugin/marketplace.json"))' 'n=0' 'for p in d.get("plugins",[]):' '  v=p.get("version","MISSING")' '  nm=p.get("name","unknown")' '  if v!=e:' '    print(f"ERROR: .claude-plugin/marketplace.json plugin {nm!r} has {v!r}, expected {e!r}")' '    n+=1' '  else:' '    print(f"OK: .claude-plugin/marketplace.json plugin {nm!r} (v{v})")' 'sys.exit(n)' > /tmp/_mp_release_check.py
-          python3 /tmp/_mp_release_check.py "$expected"
+          tag="${{ steps.version.outputs.tag }}"
+          git show "${tag}:.claude-plugin/marketplace.json" | python3 - "$expected" << 'PYEOF'
+          import json, sys
+          expected = sys.argv[1]
+          data = json.load(sys.stdin)
+          errors = 0
+          for p in data.get('plugins', []):
+              actual = p.get('version', 'MISSING')
+              name = p.get('name', 'unknown')
+              if actual != expected:
+                  print(f"ERROR: marketplace.json plugin '{name}' has '{actual}', expected '{expected}'")
+                  errors += 1
+              else:
+                  print(f"OK: marketplace.json '{name}' (v{actual})")
+          sys.exit(errors)
+          PYEOF
 
       - name: Validate SKILL.md versions match tag
         run: |
           expected="${{ steps.version.outputs.version }}"
+          tag="${{ steps.version.outputs.tag }}"
           errors=0
-          for skill_file in plugins/*/skills/*/SKILL.md; do
-            if [ -f "$skill_file" ]; then
-              actual=$(head -20 "$skill_file" | grep '^version:' | sed 's/version: //')
-              if [ -z "$actual" ]; then
-                echo "ERROR: Missing version in frontmatter: $skill_file"
-                errors=$((errors + 1))
-              elif [ "$actual" != "$expected" ]; then
-                echo "ERROR: $skill_file has version '${actual}', expected '${expected}'"
-                errors=$((errors + 1))
-              else
-                echo "OK: $skill_file (v${actual})"
-              fi
+          for skill_file in plugins/hawkscan/skills/hawkscan/SKILL.md plugins/api/skills/api/SKILL.md; do
+            actual=$(git show "${tag}:${skill_file}" | head -20 | grep '^version:' | sed 's/version: //')
+            if [ -z "$actual" ]; then
+              echo "ERROR: Missing version in frontmatter at tag: ${skill_file}"
+              errors=$((errors + 1))
+            elif [ "$actual" != "$expected" ]; then
+              echo "ERROR: ${skill_file} has version '${actual}', expected '${expected}'"
+              errors=$((errors + 1))
+            else
+              echo "OK: ${skill_file} (v${actual})"
             fi
           done
           if [ $errors -gt 0 ]; then
@@ -147,20 +120,27 @@ jobs:
       - name: Extract changelog section for this version
         id: changelog
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          notes=$(awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{found=0} found{print}" CHANGELOG.md)
+          version="${{ steps.version.outputs.version }}"
+          tag="${{ steps.version.outputs.tag }}"
+          notes=$(git show "${tag}:CHANGELOG.md" | awk "/^## \\[${version}\\]/{found=1; next} /^## \\[/{found=0} found{print}")
           if [ -z "$notes" ]; then
-            notes="Release ${VERSION}"
+            notes="Release ${tag}"
           fi
           printf '%s' "$notes" > /tmp/release-notes.txt
-          echo "notes_file=/tmp/release-notes.txt" >> "$GITHUB_OUTPUT"
+          cat /tmp/release-notes.txt
 
       - name: Create GitHub Release
-        if: "!(github.event_name == 'workflow_dispatch' && inputs.dry_run == true)"
+        if: inputs.dry_run != true
         run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --notes-file "${{ steps.changelog.outputs.notes_file }}"
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "${{ steps.version.outputs.tag }}" \
+            --notes-file /tmp/release-notes.txt
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Dry run summary
+        if: inputs.dry_run == true
+        run: |
+          echo "DRY RUN: all checks passed for ${{ steps.version.outputs.tag }}"
+          echo "Release notes preview:"
+          cat /tmp/release-notes.txt

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -1,0 +1,32 @@
+name: Tag on merge
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Create version tag
+        run: |
+          version=$(cat VERSION)
+          tag="v${version}"
+
+          if git rev-parse --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "Tag '${tag}' already exists — skipping (VERSION was not bumped in this push)"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${tag}" -m "${tag}"
+          git push origin "${tag}"
+          echo "Created tag: ${tag}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Redesigns the release workflow to match the HawkScan pattern: tag every merge, promote a specific tag to a GH Release manually.

**`tag-on-merge.yml`** (new) — fires on every push to `main`:
- Reads `VERSION`, creates annotated tag `v{VERSION}`
- Silent no-op if the tag already exists (handles hotfixes or pushes without a version bump)

**`release.yml`** (updated) — `workflow_dispatch` with a `tag` input:
- User picks which existing tag to release (e.g. `v1.6.2`)
- Validates all version fields **at that tag** (VERSION file, all manifests, marketplace plugin array, SKILL.md frontmatter) — reads from git history, not the working tree
- Extracts the matching CHANGELOG section from that tag
- Creates the GH Release
- `dry_run=true` previews release notes without creating the release

## New release flow

```
PR merged → main → tag-on-merge creates v1.6.3 automatically

Later: Actions → Release → Run workflow
  tag: v1.6.3
  dry_run: false
  → GH Release created
```

## Why this is better

- Every merge gets a tag, so you have a full audit trail of what shipped and when
- Releases are deliberate promotions of a specific tag, not always "latest"
- Matches the HawkScan release pattern

## Test Plan

- [ ] Merge a PR to main → confirm `tag-on-merge` creates `v{VERSION}` tag automatically
- [ ] Merge another PR without bumping VERSION → confirm tag-on-merge no-ops cleanly
- [ ] Run Release workflow with `dry_run=true` on an existing tag → all checks pass, release notes preview shown, no release created
- [ ] Run Release workflow with `dry_run=false` → GH Release created with correct notes