### PR TITLE
fix: use agent-skills-amd-4cpu runner for update-marketplace job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
     name: Update marketplace pin
     needs: release
     if: inputs.dry_run != true
-    runs-on: biodome-arm-2cpu
+    runs-on: agent-skills-amd-4cpu
     steps:
       - name: Biodome job setup
         uses: ./../../../../../home/runner/.github/actions/biodome-setup-v2


### PR DESCRIPTION
## Summary

- Fixes the runner label for the `update-marketplace` job from `biodome-arm-2cpu` → `agent-skills-amd-4cpu`
- `agent-skills-amd-4cpu` is the dedicated runner set added in stackhawk/halcyon#433 for this public repo, pinned to the `agent-skills-runners` group with "Allow public repositories" enabled
- Same `biodome-runner` image, so `biodome ci save-secrets` / `TF_GITHUB_TOKEN` still work

Closes ENG-410