### PR TITLE
fix: fetch TF_GITHUB_TOKEN from AWS SSM for marketplace push (ENG-410)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,7 @@ jobs:
       - name: Clone agent-skills-marketplace
         run: |
           GH_PAT=$(aws ssm get-parameter --name TF_GITHUB_TOKEN --query 'Parameter.Value' --output text --with-decryption)
+          echo "::add-mask::${GH_PAT}"
           git clone https://github.com/stackhawk/agent-skills-marketplace.git /tmp/marketplace
           git -C /tmp/marketplace remote set-url origin \
             https://x-access-token:${GH_PAT}@github.com/stackhawk/agent-skills-marketplace.git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,9 +154,10 @@ jobs:
 
       - name: Clone agent-skills-marketplace
         run: |
+          GH_PAT=$(aws ssm get-parameter --name TF_GITHUB_TOKEN --query 'Parameter.Value' --output text --with-decryption)
           git clone https://github.com/stackhawk/agent-skills-marketplace.git /tmp/marketplace
           git -C /tmp/marketplace remote set-url origin \
-            https://x-access-token:${TF_GITHUB_TOKEN}@github.com/stackhawk/agent-skills-marketplace.git
+            https://x-access-token:${GH_PAT}@github.com/stackhawk/agent-skills-marketplace.git
 
       - name: Update marketplace.json
         run: |


### PR DESCRIPTION
## Summary

The `update-marketplace` job was failing with:
```
remote: Invalid username or token. Password authentication is not supported for Git operations.
```

`biodome ci save-secrets` sets up AWS credentials but does not export `TF_GITHUB_TOKEN` as a shell env var. The token lives in AWS SSM Parameter Store under `TF_GITHUB_TOKEN`.

Fix: fetch the token directly from SSM using the AWS CLI (which works because biodome sets up the AWS profile):

```bash
GH_PAT=$(aws ssm get-parameter --name TF_GITHUB_TOKEN --query 'Parameter.Value' --output text --with-decryption)
```

This matches the pattern in halcyon `BOOTSTRAPPING.md` and the aerie Gradle plugin (`Aws.awsInfraProfile().getAccountParameter("TF_GITHUB_TOKEN")`).

Closes ENG-410