### PR TITLE
Marketplace catalog generator + install-verify workflow + publisher fix (ENG-532)

### DIFF
--- a/.github/workflows/marketplace-install-verify.yml
+++ b/.github/workflows/marketplace-install-verify.yml
@@ -1,0 +1,276 @@
+name: Marketplace Install Verify
+
+# Ephemeral, on-demand verification that the EXACT install commands we publish to
+# users (raptor-ui vibe getting-started, barnswallow docs) actually work against the
+# LIVE stackhawk/agent-skills-marketplace catalog.
+#
+# This is deliberately NOT the skill-evals harness. skill-evals loads plugins
+# locally (claude --plugin-dir, `codex plugin marketplace add .`, `gemini
+# extensions link`, cursor copies .mdc rules) to grade skill *quality*. This
+# workflow does the opposite: it installs from the published REMOTE marketplace
+# exactly as a user would, and asserts the plugin/skill landed. Plumbing, not quality.
+#
+# It is never wired into release CI — run it by hand (workflow_dispatch) whenever we
+# change a catalog or want to re-prove the documented commands. Each tool is its own
+# job so they go green/red independently; the run page is the acceptance artifact.
+#
+# v1 is diagnostic-heavy on purpose: the non-interactive `plugin` surface for
+# claude / copilot / cursor is exactly what we're proving, so every job dumps its
+# CLI's plugin/extension help and the install output before the hard verify step.
+
+on:
+  # TEMPORARY (remove before merge): lets us iterate on this workflow from the
+  # feature branch. workflow_dispatch only becomes dispatchable once the file is on
+  # the default branch, so a push trigger scoped to this branch is how we test pre-merge.
+  push:
+    branches: [bdub/eng-532-marketplace-install-verification]
+  workflow_dispatch:
+    inputs:
+      marketplace_repo:
+        description: "Marketplace repo (owner/repo) the catalog tools install from"
+        required: true
+        default: "stackhawk/agent-skills-marketplace"
+        type: string
+      gemini_source:
+        description: "Gemini installs direct from agent-skills (no catalog) — repo URL"
+        required: true
+        default: "https://github.com/stackhawk/agent-skills"
+        type: string
+      tool:
+        description: "Which tool to verify"
+        required: true
+        default: "all"
+        type: choice
+        options: [all, claude-code, codex, copilot, gemini, cursor]
+
+permissions:
+  contents: read
+
+env:
+  # Marketplace `name` field in both .claude-plugin/ and .codex-plugin/ catalogs.
+  MARKETPLACE_NAME: stackhawk
+  # Plugin identifiers as published in the catalogs (NOTE: api is "stackhawk-api").
+  PLUGIN_1: hawkscan
+  PLUGIN_2: stackhawk-api
+  # workflow_dispatch inputs assigned to env once here (the recommended safe
+  # pattern) so run: steps reference $MARKETPLACE_REPO / $GEMINI_SOURCE instead of
+  # interpolating ${{ inputs.* }} into a shell command (avoids injection surface).
+  # `|| '...'` supplies the default on push events (push carries no inputs).
+  MARKETPLACE_REPO: ${{ inputs.marketplace_repo || 'stackhawk/agent-skills-marketplace' }}
+  GEMINI_SOURCE: ${{ inputs.gemini_source || 'https://github.com/stackhawk/agent-skills' }}
+
+jobs:
+  # ── Claude Code ────────────────────────────────────────────────────────────
+  claude-code:
+    name: claude-code
+    if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'claude-code' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Claude Code CLI (native)
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Versions + plugin surface (diagnostic)
+        continue-on-error: true
+        run: |
+          set -x
+          claude --version
+          claude --help || true
+          claude plugin --help || true
+          claude plugin marketplace --help || true
+      - name: Add marketplace + install plugins
+        continue-on-error: true
+        run: |
+          set -x
+          claude plugin marketplace add "$MARKETPLACE_REPO"
+          claude plugin install "${PLUGIN_1}@${MARKETPLACE_NAME}"
+          claude plugin install "${PLUGIN_2}@${MARKETPLACE_NAME}"
+      - name: List installed (diagnostic)
+        continue-on-error: true
+        run: |
+          set -x
+          claude plugin list || true
+          claude plugin marketplace list || true
+          echo "--- ~/.claude/plugins ---"; ls -laR "$HOME/.claude/plugins" 2>/dev/null | head -80 || true
+      - name: Verify both plugins present
+        run: |
+          set -euo pipefail
+          out="$(claude plugin list 2>&1 || true)"
+          echo "$out"
+          echo "$out" | grep -q "${PLUGIN_1}" || { echo "MISSING: ${PLUGIN_1}"; exit 1; }
+          echo "$out" | grep -q "${PLUGIN_2}" || { echo "MISSING: ${PLUGIN_2}"; exit 1; }
+          echo "OK: both plugins installed from $MARKETPLACE_REPO"
+
+  # ── Codex ──────────────────────────────────────────────────────────────────
+  codex:
+    name: codex
+    if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'codex' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install Codex CLI
+        run: npm install -g @openai/codex
+      - name: Authenticate codex CLI
+        continue-on-error: true
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        # codex reads stored creds, not the env var directly; pipe via stdin.
+        run: printenv OPENAI_API_KEY | codex login --with-api-key
+      - name: Versions + plugin surface (diagnostic)
+        continue-on-error: true
+        run: |
+          set -x
+          codex --version
+          codex plugin --help || true
+          codex plugin marketplace --help || true
+      - name: Add marketplace + install plugins
+        continue-on-error: true
+        # skill-evals proves the verb set: `marketplace add <src>` + `plugin add
+        # <name>@<mkt>`, confirming interactive prompts with `echo y`.
+        run: |
+          set -x
+          codex plugin marketplace add "$MARKETPLACE_REPO"
+          echo y | codex plugin add "${PLUGIN_1}@${MARKETPLACE_NAME}"
+          echo y | codex plugin add "${PLUGIN_2}@${MARKETPLACE_NAME}"
+      - name: List installed (diagnostic)
+        continue-on-error: true
+        run: |
+          set -x
+          codex plugin list || true
+          codex plugin marketplace list || true
+      - name: Verify both plugins present
+        run: |
+          set -euo pipefail
+          out="$(codex plugin list 2>&1 || true)"
+          echo "$out"
+          echo "$out" | grep -q "${PLUGIN_1}" || { echo "MISSING: ${PLUGIN_1}"; exit 1; }
+          echo "$out" | grep -q "${PLUGIN_2}" || { echo "MISSING: ${PLUGIN_2}"; exit 1; }
+          echo "OK: both plugins installed from $MARKETPLACE_REPO"
+
+  # ── GitHub Copilot CLI ───────────────────────────────────────────────────────
+  copilot:
+    name: copilot
+    if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'copilot' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install GitHub Copilot CLI
+        # The new standalone CLI (github/copilot-cli), NOT the old `gh copilot`
+        # extension. Distributed on npm as @github/copilot.
+        run: npm install -g @github/copilot
+      - name: Versions + plugin surface (diagnostic)
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -x
+          copilot --version || true
+          copilot --help || true
+          copilot plugin --help || true
+          copilot plugin marketplace --help || true
+      - name: Add marketplace + install plugins
+        continue-on-error: true
+        # Copilot reads .claude-plugin/marketplace.json directly and accepts the
+        # Claude spec with object/remote sources — so it should ride our existing
+        # catalog with no copilot-specific manifest. This step proves (or disproves) it.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -x
+          copilot plugin marketplace add "$MARKETPLACE_REPO"
+          copilot plugin install "${PLUGIN_1}@${MARKETPLACE_NAME}"
+          copilot plugin install "${PLUGIN_2}@${MARKETPLACE_NAME}"
+      - name: List installed (diagnostic)
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -x
+          copilot plugin list || true
+          copilot plugin marketplace list || true
+      - name: Verify both plugins present
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          out="$(copilot plugin list 2>&1 || true)"
+          echo "$out"
+          echo "$out" | grep -q "${PLUGIN_1}" || { echo "MISSING: ${PLUGIN_1}"; exit 1; }
+          echo "$out" | grep -q "${PLUGIN_2}" || { echo "MISSING: ${PLUGIN_2}"; exit 1; }
+          echo "OK: both plugins installed from $MARKETPLACE_REPO"
+
+  # ── Gemini CLI ───────────────────────────────────────────────────────────────
+  gemini:
+    name: gemini
+    if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'gemini' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install Gemini CLI
+        run: npm install -g @google/gemini-cli
+      - name: Versions + extensions surface (diagnostic)
+        continue-on-error: true
+        run: |
+          set -x
+          gemini --version || true
+          gemini extensions --help || true
+      - name: Install extension (direct from agent-skills, unpinned)
+        continue-on-error: true
+        # Gemini has no catalog model — it installs the extension straight from the
+        # repo URL. Product decision: unpinned (no --ref).
+        run: |
+          set -x
+          gemini extensions install "$GEMINI_SOURCE"
+      - name: List installed (diagnostic)
+        continue-on-error: true
+        run: |
+          set -x
+          gemini extensions list || true
+          echo "--- ~/.gemini/extensions ---"; ls -laR "$HOME/.gemini/extensions" 2>/dev/null | head -60 || true
+      - name: Verify extension present
+        run: |
+          set -euo pipefail
+          out="$(gemini extensions list 2>&1 || true)"
+          echo "$out"
+          # The extension name comes from agent-skills/gemini-extension.json; match
+          # on the repo slug or a stackhawk/hawkscan marker.
+          echo "$out" | grep -iqE "stackhawk|hawkscan|agent-skills" || { echo "MISSING: stackhawk extension"; exit 1; }
+          echo "OK: extension installed from $GEMINI_SOURCE"
+
+  # ── Cursor ───────────────────────────────────────────────────────────────────
+  cursor:
+    name: cursor
+    if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'cursor' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Cursor CLI
+        continue-on-error: true
+        run: |
+          # Official installer symlinks the `agent` binary into ~/.local/bin.
+          curl https://cursor.com/install -fsS | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Discover CLI surface (diagnostic)
+        # Cursor's marketplace is editor/dashboard-driven (/add-plugin, "Import from
+        # Repo"); whether the `agent` CLI can install a marketplace plugin headlessly
+        # is unknown. v1 only maps the surface — we design the real test from this.
+        continue-on-error: true
+        run: |
+          set -x
+          agent --version || true
+          agent --help || true
+          agent plugin --help 2>/dev/null || true
+          agent marketplace --help 2>/dev/null || true
+      - name: Note
+        run: |
+          echo "Cursor verification is exploratory in v1 — see diagnostic output above."
+          echo "Cursor marketplace install is editor/dashboard-driven; CLI surface TBD."

--- a/.github/workflows/marketplace-install-verify.yml
+++ b/.github/workflows/marketplace-install-verify.yml
@@ -267,13 +267,7 @@ jobs:
     if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'agy' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Rewrite git SSH->HTTPS
-        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
       - name: Install agy CLI
-        continue-on-error: true
         run: |
           # /cli/install.sh is the real bootstrapper (per skill-evals); installer drops
           # `agy` into ~/.local/bin.
@@ -281,46 +275,27 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Command surface (diagnostic)
         continue-on-error: true
+        # Discovery confirmed: agy has NO `marketplace add` / `plugin add` verbs. It uses
+        # `plugin install <target>` (target may be a repo URL or `name@marketplace`) and
+        # `plugin link <mp> <target>`. Product call: agy installs direct + unpinned, so we
+        # verify the repo-URL form (the literal raptor-ui command).
         run: |
           set -x
           agy --version || true
-          agy --help || true
           agy plugin --help || true
-          agy plugin marketplace --help 2>/dev/null || true
-          agy plugin add --help 2>/dev/null || true
-          agy plugin install --help 2>/dev/null || true
-      - name: Generate catalogs (for the marketplace path attempt)
-        continue-on-error: true
-        run: |
-          set -euxo pipefail
-          TAG=$(git describe --tags --abbrev=0)
-          SHA=$(git rev-list -n1 "$TAG")
-          python3 scripts/generate-marketplace-catalogs.py --tag "$TAG" --sha "$SHA" --out-dir /tmp/mp
-      - name: Try marketplace path (agy reads .agents/plugins/ like codex?)
-        continue-on-error: true
+      - name: Install (direct from agent-skills, unpinned)
         env:
           ANTIGRAVITY_API_KEY: ${{ secrets.AGY_API_KEY }}
+        run: echo y | agy plugin install "$AGY_SOURCE"
+      - name: Verify the stackhawk plugin imported
         run: |
-          set -x
-          agy plugin marketplace add /tmp/mp 2>&1 || echo "[marketplace add unsupported/failed]"
-          echo y | agy plugin add "hawkscan@${MARKETPLACE_NAME}" 2>&1 || echo "[plugin add unsupported/failed]"
-      - name: Try direct path (current raptor-ui command)
-        continue-on-error: true
-        env:
-          ANTIGRAVITY_API_KEY: ${{ secrets.AGY_API_KEY }}
-        run: |
-          set -x
-          echo y | agy plugin install "$AGY_SOURCE" 2>&1 || echo "[direct install failed — likely OAuth-gated in CI]"
-      - name: List installed (diagnostic)
-        continue-on-error: true
-        run: |
-          set -x
-          agy plugin list 2>&1 || true
-          agy plugin marketplace list 2>&1 || true
-      - name: Note
-        run: |
-          echo "agy is DISCOVERY-ONLY here. Read the surface above to decide direct vs"
-          echo "marketplace. A real install may be OAuth-gated in CI (antigravity-cli#78)."
+          set -euo pipefail
+          out="$(agy plugin list 2>&1 || true)"
+          echo "$out"
+          # `agy plugin list` emits JSON with an "imports" array; the StackHawk import
+          # registers as name "stackhawk".
+          echo "$out" | grep -iq '"stackhawk"' || { echo "MISSING: stackhawk import"; exit 1; }
+          echo "OK: agy imported stackhawk skills from $AGY_SOURCE"
 
   # ── Cursor ───────────────────────────────────────────────────────────────────
   cursor:

--- a/.github/workflows/marketplace-install-verify.yml
+++ b/.github/workflows/marketplace-install-verify.yml
@@ -40,8 +40,8 @@ on:
         required: true
         default: "stackhawk/agent-skills-marketplace"
         type: string
-      gemini_source:
-        description: "Gemini installs direct from agent-skills (no catalog) — repo URL"
+      agy_source:
+        description: "Antigravity (agy) direct-install source — agent-skills repo URL"
         required: true
         default: "https://github.com/stackhawk/agent-skills"
         type: string
@@ -50,7 +50,7 @@ on:
         required: true
         default: "all"
         type: choice
-        options: [all, claude-code, codex, copilot, gemini, cursor]
+        options: [all, claude-code, codex, copilot, agy, cursor]
 
 permissions:
   contents: read
@@ -64,7 +64,7 @@ env:
   # Inputs -> env once (safe pattern); `|| '...'` supplies defaults on push.
   SOURCE_MODE: ${{ inputs.source_mode || 'local' }}
   MARKETPLACE_REPO: ${{ inputs.marketplace_repo || 'stackhawk/agent-skills-marketplace' }}
-  GEMINI_SOURCE: ${{ inputs.gemini_source || 'https://github.com/stackhawk/agent-skills' }}
+  AGY_SOURCE: ${{ inputs.agy_source || 'https://github.com/stackhawk/agent-skills' }}
 
 jobs:
   # ── Claude Code ────────────────────────────────────────────────────────────
@@ -253,52 +253,74 @@ jobs:
           echo "$out" | grep -q "${PLUGIN_2}" || { echo "MISSING: ${PLUGIN_2}"; exit 1; }
           echo "OK: both plugins installed (mode=$SOURCE_MODE src=$MP_SRC)"
 
-  # ── Gemini CLI ───────────────────────────────────────────────────────────────
-  gemini:
-    name: gemini
-    if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'gemini' }}
+  # ── Antigravity (agy) ────────────────────────────────────────────────────────
+  # StackHawk's 5th tool is Google Antigravity (`agy`), the successor to the Gemini
+  # CLI — NOT the Gemini CLI itself (the raptor-ui card is labelled "Gemini CLI" but
+  # runs agy). This job is DISCOVERY-ONLY: it maps agy's plugin/marketplace command
+  # surface and tries both install paths, so we can decide (with the user) whether agy
+  # rides the marketplace (it uses the same .agents/ standard as Codex) or stays on
+  # direct `agy plugin install <url>`. NOTE: skill-evals documents that agy ignores
+  # API-key env and forces interactive Google OAuth in CI (antigravity-cli#78) — so an
+  # actual headless install may not complete here; the --help surface still will.
+  agy:
+    name: agy
+    if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'agy' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
         with:
-          node-version: "20"
-      - name: Install Gemini CLI
-        run: npm install -g @google/gemini-cli
-      - name: Pre-trust workspace (avoid interactive trust prompt)
-        # gemini blocks `extensions install` on an interactive "trust this workspace?"
-        # prompt. Disable folder-trust in user settings so it proceeds non-interactively.
+          fetch-depth: 0
+      - name: Rewrite git SSH->HTTPS
+        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+      - name: Install agy CLI
+        continue-on-error: true
         run: |
-          set -x
-          mkdir -p "$HOME/.gemini"
-          printf '%s\n' '{ "security": { "folderTrust": { "enabled": false } } }' > "$HOME/.gemini/settings.json"
-          cat "$HOME/.gemini/settings.json"
-      - name: Extensions surface (diagnostic)
+          # /cli/install.sh is the real bootstrapper (per skill-evals); installer drops
+          # `agy` into ~/.local/bin.
+          curl -fsSL https://antigravity.google/cli/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Command surface (diagnostic)
         continue-on-error: true
         run: |
           set -x
-          gemini --version || true
-          gemini extensions --help || true
-      - name: Install extension (direct from agent-skills, unpinned)
+          agy --version || true
+          agy --help || true
+          agy plugin --help || true
+          agy plugin marketplace --help 2>/dev/null || true
+          agy plugin add --help 2>/dev/null || true
+          agy plugin install --help 2>/dev/null || true
+      - name: Generate catalogs (for the marketplace path attempt)
         continue-on-error: true
-        # Gemini has no catalog model — installs straight from the repo URL. Product
-        # decision: unpinned (no --ref). </dev/null + timeout guard against any prompt.
+        run: |
+          set -euxo pipefail
+          TAG=$(git describe --tags --abbrev=0)
+          SHA=$(git rev-list -n1 "$TAG")
+          python3 scripts/generate-marketplace-catalogs.py --tag "$TAG" --sha "$SHA" --out-dir /tmp/mp
+      - name: Try marketplace path (agy reads .agents/plugins/ like codex?)
+        continue-on-error: true
+        env:
+          ANTIGRAVITY_API_KEY: ${{ secrets.AGY_API_KEY }}
         run: |
           set -x
-          printf 'y\n' | timeout 240 gemini extensions install "$GEMINI_SOURCE" || \
-            timeout 240 gemini extensions install "$GEMINI_SOURCE" </dev/null
+          agy plugin marketplace add /tmp/mp 2>&1 || echo "[marketplace add unsupported/failed]"
+          echo y | agy plugin add "hawkscan@${MARKETPLACE_NAME}" 2>&1 || echo "[plugin add unsupported/failed]"
+      - name: Try direct path (current raptor-ui command)
+        continue-on-error: true
+        env:
+          ANTIGRAVITY_API_KEY: ${{ secrets.AGY_API_KEY }}
+        run: |
+          set -x
+          echo y | agy plugin install "$AGY_SOURCE" 2>&1 || echo "[direct install failed — likely OAuth-gated in CI]"
       - name: List installed (diagnostic)
         continue-on-error: true
         run: |
           set -x
-          gemini extensions list || true
-          echo "--- ~/.gemini/extensions ---"; ls -laR "$HOME/.gemini/extensions" 2>/dev/null | head -60 || true
-      - name: Verify extension present
+          agy plugin list 2>&1 || true
+          agy plugin marketplace list 2>&1 || true
+      - name: Note
         run: |
-          set -euo pipefail
-          out="$(gemini extensions list 2>&1 || true)"
-          echo "$out"
-          echo "$out" | grep -iqE "stackhawk|hawkscan|agent-skills" || { echo "MISSING: stackhawk extension"; exit 1; }
-          echo "OK: extension installed from $GEMINI_SOURCE"
+          echo "agy is DISCOVERY-ONLY here. Read the surface above to decide direct vs"
+          echo "marketplace. A real install may be OAuth-gated in CI (antigravity-cli#78)."
 
   # ── Cursor ───────────────────────────────────────────────────────────────────
   cursor:

--- a/.github/workflows/marketplace-install-verify.yml
+++ b/.github/workflows/marketplace-install-verify.yml
@@ -1,33 +1,42 @@
 name: Marketplace Install Verify
 
-# Ephemeral, on-demand verification that the EXACT install commands we publish to
-# users (raptor-ui vibe getting-started, barnswallow docs) actually work against the
-# LIVE stackhawk/agent-skills-marketplace catalog.
+# Ephemeral, on-demand verification that the EXACT install path we publish to users
+# (raptor-ui vibe getting-started, barnswallow docs) actually works.
 #
 # This is deliberately NOT the skill-evals harness. skill-evals loads plugins
-# locally (claude --plugin-dir, `codex plugin marketplace add .`, `gemini
-# extensions link`, cursor copies .mdc rules) to grade skill *quality*. This
-# workflow does the opposite: it installs from the published REMOTE marketplace
-# exactly as a user would, and asserts the plugin/skill landed. Plumbing, not quality.
+# locally to grade skill *quality*. This workflow installs from a marketplace catalog
+# exactly as a user would and asserts the plugin/skill landed — plumbing, not quality.
+# Never wired into release CI; run it by hand. Each tool is its own job so they go
+# green/red independently; the run page is the acceptance artifact.
 #
-# It is never wired into release CI — run it by hand (workflow_dispatch) whenever we
-# change a catalog or want to re-prove the documented commands. Each tool is its own
-# job so they go green/red independently; the run page is the acceptance artifact.
+# SOURCE MODE
+#   local  (default while iterating): run scripts/generate-marketplace-catalogs.py
+#          against this checkout to produce the catalogs the publisher will ship, then
+#          `<tool> marketplace add <generated dir>`. Proves the GENERATED catalog (the
+#          exact bytes the release publisher pushes) is installable — without needing
+#          push access to the marketplace repo.
+#   remote: `<tool> marketplace add owner/repo` — the literal user command. Proves the
+#          end-to-end remote UX once generated catalogs are merged to the marketplace main.
 #
-# v1 is diagnostic-heavy on purpose: the non-interactive `plugin` surface for
-# claude / copilot / cursor is exactly what we're proving, so every job dumps its
-# CLI's plugin/extension help and the install output before the hard verify step.
+# The catalog plugin sources are REMOTE github sources (repo + path + ref + sha), so
+# each tool clones agent-skills to fetch the plugin. CI has no SSH key, so every
+# catalog job rewrites git SSH->HTTPS first.
 
 on:
-  # TEMPORARY (remove before merge): lets us iterate on this workflow from the
-  # feature branch. workflow_dispatch only becomes dispatchable once the file is on
-  # the default branch, so a push trigger scoped to this branch is how we test pre-merge.
+  # TEMPORARY (remove before merge): lets us iterate from the feature branch.
+  # workflow_dispatch only becomes dispatchable once the file is on the default branch.
   push:
     branches: [bdub/eng-532-marketplace-install-verification]
   workflow_dispatch:
     inputs:
+      source_mode:
+        description: "local = generate catalogs + install from dir; remote = marketplace add owner/repo"
+        required: true
+        default: "local"
+        type: choice
+        options: [local, remote]
       marketplace_repo:
-        description: "Marketplace repo (owner/repo) the catalog tools install from"
+        description: "Marketplace repo (owner/repo) used in remote mode"
         required: true
         default: "stackhawk/agent-skills-marketplace"
         type: string
@@ -52,10 +61,8 @@ env:
   # Plugin identifiers as published in the catalogs (NOTE: api is "stackhawk-api").
   PLUGIN_1: hawkscan
   PLUGIN_2: stackhawk-api
-  # workflow_dispatch inputs assigned to env once here (the recommended safe
-  # pattern) so run: steps reference $MARKETPLACE_REPO / $GEMINI_SOURCE instead of
-  # interpolating ${{ inputs.* }} into a shell command (avoids injection surface).
-  # `|| '...'` supplies the default on push events (push carries no inputs).
+  # Inputs -> env once (safe pattern); `|| '...'` supplies defaults on push.
+  SOURCE_MODE: ${{ inputs.source_mode || 'local' }}
   MARKETPLACE_REPO: ${{ inputs.marketplace_repo || 'stackhawk/agent-skills-marketplace' }}
   GEMINI_SOURCE: ${{ inputs.gemini_source || 'https://github.com/stackhawk/agent-skills' }}
 
@@ -66,23 +73,38 @@ jobs:
     if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'claude-code' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need tags for `git describe` in local mode
+      - name: Rewrite git SSH->HTTPS
+        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
       - name: Install Claude Code CLI (native)
         run: |
           curl -fsSL https://claude.ai/install.sh | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-      - name: Versions + plugin surface (diagnostic)
+      - name: Resolve marketplace source
+        run: |
+          set -euxo pipefail
+          if [ "$SOURCE_MODE" = "local" ]; then
+            TAG=$(git describe --tags --abbrev=0)
+            SHA=$(git rev-list -n1 "$TAG")
+            python3 scripts/generate-marketplace-catalogs.py --tag "$TAG" --sha "$SHA" --out-dir /tmp/mp
+            echo "MP_SRC=/tmp/mp" >> "$GITHUB_ENV"
+          else
+            echo "MP_SRC=${MARKETPLACE_REPO}" >> "$GITHUB_ENV"
+          fi
+      - name: Plugin surface (diagnostic)
         continue-on-error: true
         run: |
           set -x
           claude --version
-          claude --help || true
           claude plugin --help || true
           claude plugin marketplace --help || true
       - name: Add marketplace + install plugins
         continue-on-error: true
         run: |
           set -x
-          claude plugin marketplace add "$MARKETPLACE_REPO"
+          claude plugin marketplace add "$MP_SRC"
           claude plugin install "${PLUGIN_1}@${MARKETPLACE_NAME}"
           claude plugin install "${PLUGIN_2}@${MARKETPLACE_NAME}"
       - name: List installed (diagnostic)
@@ -91,7 +113,6 @@ jobs:
           set -x
           claude plugin list || true
           claude plugin marketplace list || true
-          echo "--- ~/.claude/plugins ---"; ls -laR "$HOME/.claude/plugins" 2>/dev/null | head -80 || true
       - name: Verify both plugins present
         run: |
           set -euo pipefail
@@ -99,7 +120,7 @@ jobs:
           echo "$out"
           echo "$out" | grep -q "${PLUGIN_1}" || { echo "MISSING: ${PLUGIN_1}"; exit 1; }
           echo "$out" | grep -q "${PLUGIN_2}" || { echo "MISSING: ${PLUGIN_2}"; exit 1; }
-          echo "OK: both plugins installed from $MARKETPLACE_REPO"
+          echo "OK: both plugins installed (mode=$SOURCE_MODE src=$MP_SRC)"
 
   # ── Codex ──────────────────────────────────────────────────────────────────
   codex:
@@ -107,6 +128,11 @@ jobs:
     if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'codex' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Rewrite git SSH->HTTPS
+        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -116,9 +142,19 @@ jobs:
         continue-on-error: true
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        # codex reads stored creds, not the env var directly; pipe via stdin.
         run: printenv OPENAI_API_KEY | codex login --with-api-key
-      - name: Versions + plugin surface (diagnostic)
+      - name: Resolve marketplace source
+        run: |
+          set -euxo pipefail
+          if [ "$SOURCE_MODE" = "local" ]; then
+            TAG=$(git describe --tags --abbrev=0)
+            SHA=$(git rev-list -n1 "$TAG")
+            python3 scripts/generate-marketplace-catalogs.py --tag "$TAG" --sha "$SHA" --out-dir /tmp/mp
+            echo "MP_SRC=/tmp/mp" >> "$GITHUB_ENV"
+          else
+            echo "MP_SRC=${MARKETPLACE_REPO}" >> "$GITHUB_ENV"
+          fi
+      - name: Plugin surface (diagnostic)
         continue-on-error: true
         run: |
           set -x
@@ -131,7 +167,7 @@ jobs:
         # <name>@<mkt>`, confirming interactive prompts with `echo y`.
         run: |
           set -x
-          codex plugin marketplace add "$MARKETPLACE_REPO"
+          codex plugin marketplace add "$MP_SRC"
           echo y | codex plugin add "${PLUGIN_1}@${MARKETPLACE_NAME}"
           echo y | codex plugin add "${PLUGIN_2}@${MARKETPLACE_NAME}"
       - name: List installed (diagnostic)
@@ -147,7 +183,7 @@ jobs:
           echo "$out"
           echo "$out" | grep -q "${PLUGIN_1}" || { echo "MISSING: ${PLUGIN_1}"; exit 1; }
           echo "$out" | grep -q "${PLUGIN_2}" || { echo "MISSING: ${PLUGIN_2}"; exit 1; }
-          echo "OK: both plugins installed from $MARKETPLACE_REPO"
+          echo "OK: both plugins installed (mode=$SOURCE_MODE src=$MP_SRC)"
 
   # ── GitHub Copilot CLI ───────────────────────────────────────────────────────
   copilot:
@@ -155,14 +191,28 @@ jobs:
     if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'copilot' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Rewrite git SSH->HTTPS
+        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
       - name: Install GitHub Copilot CLI
-        # The new standalone CLI (github/copilot-cli), NOT the old `gh copilot`
-        # extension. Distributed on npm as @github/copilot.
         run: npm install -g @github/copilot
-      - name: Versions + plugin surface (diagnostic)
+      - name: Resolve marketplace source
+        run: |
+          set -euxo pipefail
+          if [ "$SOURCE_MODE" = "local" ]; then
+            TAG=$(git describe --tags --abbrev=0)
+            SHA=$(git rev-list -n1 "$TAG")
+            python3 scripts/generate-marketplace-catalogs.py --tag "$TAG" --sha "$SHA" --out-dir /tmp/mp
+            echo "MP_SRC=/tmp/mp" >> "$GITHUB_ENV"
+          else
+            echo "MP_SRC=${MARKETPLACE_REPO}" >> "$GITHUB_ENV"
+          fi
+      - name: Plugin surface (diagnostic)
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -170,20 +220,16 @@ jobs:
         run: |
           set -x
           copilot --version || true
-          copilot --help || true
           copilot plugin --help || true
           copilot plugin marketplace --help || true
       - name: Add marketplace + install plugins
         continue-on-error: true
-        # Copilot reads .claude-plugin/marketplace.json directly and accepts the
-        # Claude spec with object/remote sources — so it should ride our existing
-        # catalog with no copilot-specific manifest. This step proves (or disproves) it.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -x
-          copilot plugin marketplace add "$MARKETPLACE_REPO"
+          copilot plugin marketplace add "$MP_SRC"
           copilot plugin install "${PLUGIN_1}@${MARKETPLACE_NAME}"
           copilot plugin install "${PLUGIN_2}@${MARKETPLACE_NAME}"
       - name: List installed (diagnostic)
@@ -205,7 +251,7 @@ jobs:
           echo "$out"
           echo "$out" | grep -q "${PLUGIN_1}" || { echo "MISSING: ${PLUGIN_1}"; exit 1; }
           echo "$out" | grep -q "${PLUGIN_2}" || { echo "MISSING: ${PLUGIN_2}"; exit 1; }
-          echo "OK: both plugins installed from $MARKETPLACE_REPO"
+          echo "OK: both plugins installed (mode=$SOURCE_MODE src=$MP_SRC)"
 
   # ── Gemini CLI ───────────────────────────────────────────────────────────────
   gemini:
@@ -218,7 +264,15 @@ jobs:
           node-version: "20"
       - name: Install Gemini CLI
         run: npm install -g @google/gemini-cli
-      - name: Versions + extensions surface (diagnostic)
+      - name: Pre-trust workspace (avoid interactive trust prompt)
+        # gemini blocks `extensions install` on an interactive "trust this workspace?"
+        # prompt. Disable folder-trust in user settings so it proceeds non-interactively.
+        run: |
+          set -x
+          mkdir -p "$HOME/.gemini"
+          printf '%s\n' '{ "security": { "folderTrust": { "enabled": false } } }' > "$HOME/.gemini/settings.json"
+          cat "$HOME/.gemini/settings.json"
+      - name: Extensions surface (diagnostic)
         continue-on-error: true
         run: |
           set -x
@@ -226,11 +280,12 @@ jobs:
           gemini extensions --help || true
       - name: Install extension (direct from agent-skills, unpinned)
         continue-on-error: true
-        # Gemini has no catalog model — it installs the extension straight from the
-        # repo URL. Product decision: unpinned (no --ref).
+        # Gemini has no catalog model — installs straight from the repo URL. Product
+        # decision: unpinned (no --ref). </dev/null + timeout guard against any prompt.
         run: |
           set -x
-          gemini extensions install "$GEMINI_SOURCE"
+          printf 'y\n' | timeout 240 gemini extensions install "$GEMINI_SOURCE" || \
+            timeout 240 gemini extensions install "$GEMINI_SOURCE" </dev/null
       - name: List installed (diagnostic)
         continue-on-error: true
         run: |
@@ -242,8 +297,6 @@ jobs:
           set -euo pipefail
           out="$(gemini extensions list 2>&1 || true)"
           echo "$out"
-          # The extension name comes from agent-skills/gemini-extension.json; match
-          # on the repo slug or a stackhawk/hawkscan marker.
           echo "$out" | grep -iqE "stackhawk|hawkscan|agent-skills" || { echo "MISSING: stackhawk extension"; exit 1; }
           echo "OK: extension installed from $GEMINI_SOURCE"
 
@@ -256,13 +309,12 @@ jobs:
       - name: Install Cursor CLI
         continue-on-error: true
         run: |
-          # Official installer symlinks the `agent` binary into ~/.local/bin.
           curl https://cursor.com/install -fsS | bash
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Discover CLI surface (diagnostic)
-        # Cursor's marketplace is editor/dashboard-driven (/add-plugin, "Import from
-        # Repo"); whether the `agent` CLI can install a marketplace plugin headlessly
-        # is unknown. v1 only maps the surface — we design the real test from this.
+        # Cursor's marketplace is editor/dashboard-driven; whether the `agent` CLI can
+        # install a marketplace plugin headlessly is unknown. v1 maps the surface so we
+        # design the real test (or accept editor-only) from this.
         continue-on-error: true
         run: |
           set -x
@@ -272,5 +324,5 @@ jobs:
           agent marketplace --help 2>/dev/null || true
       - name: Note
         run: |
-          echo "Cursor verification is exploratory in v1 — see diagnostic output above."
+          echo "Cursor verification is exploratory — see diagnostic output above."
           echo "Cursor marketplace install is editor/dashboard-driven; CLI surface TBD."

--- a/.github/workflows/marketplace-install-verify.yml
+++ b/.github/workflows/marketplace-install-verify.yml
@@ -267,6 +267,11 @@ jobs:
     if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'agy' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Rewrite git SSH->HTTPS
+        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
       - name: Install agy CLI
         run: |
           # /cli/install.sh is the real bootstrapper (per skill-evals); installer drops
@@ -275,15 +280,41 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Command surface (diagnostic)
         continue-on-error: true
-        # Discovery confirmed: agy has NO `marketplace add` / `plugin add` verbs. It uses
-        # `plugin install <target>` (target may be a repo URL or `name@marketplace`) and
-        # `plugin link <mp> <target>`. Product call: agy installs direct + unpinned, so we
-        # verify the repo-URL form (the literal raptor-ui command).
+        # agy has NO `marketplace add`/`plugin add` verbs, but `plugin install <target>`
+        # docs say it "supports plugin@marketplace", and there is `plugin link <mp>
+        # <target>`. So agy MIGHT ride the marketplace — this job tests that for real.
         run: |
           set -x
           agy --version || true
           agy plugin --help || true
-      - name: Install (direct from agent-skills, unpinned)
+          agy plugin link --help 2>&1 || true
+          agy plugin install --help 2>&1 || true
+      - name: Generate catalog (agy reads .agents/plugins/ like codex)
+        run: |
+          set -euxo pipefail
+          TAG=$(git describe --tags --abbrev=0)
+          SHA=$(git rev-list -n1 "$TAG")
+          python3 scripts/generate-marketplace-catalogs.py --tag "$TAG" --sha "$SHA" --out-dir /tmp/mp
+          echo "--- generated .agents/plugins/marketplace.json ---"; cat /tmp/mp/.agents/plugins/marketplace.json
+      - name: MARKETPLACE PATH — try the real verbs (discovery)
+        continue-on-error: true
+        env:
+          ANTIGRAVITY_API_KEY: ${{ secrets.AGY_API_KEY }}
+        # Probe the plausible marketplace invocations; `agy plugin list` after each shows
+        # the import `source` so we can tell which (if any) registered via marketplace.
+        run: |
+          set -x
+          echo "### A: link local marketplace dir as 'stackhawk', then install name@stackhawk"
+          agy plugin link stackhawk /tmp/mp 2>&1 || echo "[link failed]"
+          echo y | agy plugin install "hawkscan@${MARKETPLACE_NAME}" 2>&1 || echo "[install name@stackhawk failed]"
+          agy plugin list 2>&1 || true
+          echo "### B: install the catalog dir directly"
+          echo y | agy plugin install /tmp/mp 2>&1 || echo "[install dir failed]"
+          agy plugin list 2>&1 || true
+          echo "### C: install plugin@<catalog-path>"
+          echo y | agy plugin install "hawkscan@/tmp/mp" 2>&1 || echo "[install name@path failed]"
+          agy plugin list 2>&1 || true
+      - name: DIRECT PATH — known-good repo-URL install (hard proof)
         env:
           ANTIGRAVITY_API_KEY: ${{ secrets.AGY_API_KEY }}
         run: echo y | agy plugin install "$AGY_SOURCE"
@@ -292,10 +323,8 @@ jobs:
           set -euo pipefail
           out="$(agy plugin list 2>&1 || true)"
           echo "$out"
-          # `agy plugin list` emits JSON with an "imports" array; the StackHawk import
-          # registers as name "stackhawk".
           echo "$out" | grep -iq '"stackhawk"' || { echo "MISSING: stackhawk import"; exit 1; }
-          echo "OK: agy imported stackhawk skills from $AGY_SOURCE"
+          echo "OK: agy imported stackhawk skills"
 
   # ── Cursor ───────────────────────────────────────────────────────────────────
   cursor:

--- a/.github/workflows/marketplace-install-verify.yml
+++ b/.github/workflows/marketplace-install-verify.yml
@@ -23,10 +23,6 @@ name: Marketplace Install Verify
 # catalog job rewrites git SSH->HTTPS first.
 
 on:
-  # TEMPORARY (remove before merge): lets us iterate from the feature branch.
-  # workflow_dispatch only becomes dispatchable once the file is on the default branch.
-  push:
-    branches: [bdub/eng-532-marketplace-install-verification]
   workflow_dispatch:
     inputs:
       source_mode:
@@ -61,7 +57,7 @@ env:
   # Plugin identifiers as published in the catalogs (NOTE: api is "stackhawk-api").
   PLUGIN_1: hawkscan
   PLUGIN_2: stackhawk-api
-  # Inputs -> env once (safe pattern); `|| '...'` supplies defaults on push.
+  # Inputs -> env once (safe pattern); `|| '...'` is a defensive default.
   SOURCE_MODE: ${{ inputs.source_mode || 'local' }}
   MARKETPLACE_REPO: ${{ inputs.marketplace_repo || 'stackhawk/agent-skills-marketplace' }}
   AGY_SOURCE: ${{ inputs.agy_source || 'https://github.com/stackhawk/agent-skills' }}
@@ -70,7 +66,7 @@ jobs:
   # ── Claude Code ────────────────────────────────────────────────────────────
   claude-code:
     name: claude-code
-    if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'claude-code' }}
+    if: ${{ inputs.tool == 'all' || inputs.tool == 'claude-code' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -125,7 +121,7 @@ jobs:
   # ── Codex ──────────────────────────────────────────────────────────────────
   codex:
     name: codex
-    if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'codex' }}
+    if: ${{ inputs.tool == 'all' || inputs.tool == 'codex' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -188,7 +184,7 @@ jobs:
   # ── GitHub Copilot CLI ───────────────────────────────────────────────────────
   copilot:
     name: copilot
-    if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'copilot' }}
+    if: ${{ inputs.tool == 'all' || inputs.tool == 'copilot' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -264,7 +260,7 @@ jobs:
   # actual headless install may not complete here; the --help surface still will.
   agy:
     name: agy
-    if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'agy' }}
+    if: ${{ inputs.tool == 'all' || inputs.tool == 'agy' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -329,7 +325,7 @@ jobs:
   # ── Cursor ───────────────────────────────────────────────────────────────────
   cursor:
     name: cursor
-    if: ${{ github.event_name == 'push' || inputs.tool == 'all' || inputs.tool == 'cursor' }}
+    if: ${{ inputs.tool == 'all' || inputs.tool == 'cursor' }}
     runs-on: ubuntu-latest
     steps:
       - name: Install Cursor CLI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,38 +178,32 @@ jobs:
           git -C /tmp/marketplace remote set-url origin \
             "https://x-access-token:${GH_PAT}@github.com/stackhawk/agent-skills-marketplace.git"
 
-      - name: Update marketplace.json
+      - name: Generate marketplace catalogs
+        # Single source of truth (scripts/generate-marketplace-catalogs.py): emits
+        # .claude-plugin/marketplace.json (also read by GitHub Copilot CLI),
+        # .agents/plugins/marketplace.json (current Codex CLI) and
+        # .codex-plugin/marketplace.json (legacy), translating local-path plugin
+        # sources into pinned remote sources WITH the per-tool schema + `path`.
+        # Replaces the old claude-only ref/sha rewrite, which left codex orphaned and
+        # never added `path` (so installs resolved the repo root and failed).
+        env:
+          TAG: ${{ needs.release.outputs.tag }}
+          SHA: ${{ steps.sha.outputs.sha }}
         run: |
-          python3 - \
-            "${{ needs.release.outputs.tag }}" \
-            "${{ steps.sha.outputs.sha }}" \
-            /tmp/marketplace/.claude-plugin/marketplace.json \
-            << 'PYEOF'
-          import json, sys
-          tag, sha, path = sys.argv[1], sys.argv[2], sys.argv[3]
-          version = tag.lstrip('v')
-          with open(path) as f:
-              data = json.load(f)
-          for plugin in data['plugins']:
-              plugin['version'] = version
-              plugin['source']['ref'] = tag
-              plugin['source']['sha'] = sha
-          out = json.dumps(data, indent=2)
-          json.loads(out)
-          with open(path, 'w') as f:
-              f.write(out + '\n')
-          print(f"Updated {len(data['plugins'])} plugin(s) to {tag} @ {sha[:7]}")
-          PYEOF
+          python3 scripts/generate-marketplace-catalogs.py \
+            --tag "$TAG" --sha "$SHA" --out-dir /tmp/marketplace
 
       - name: Commit and push
+        env:
+          TAG: ${{ needs.release.outputs.tag }}
         run: |
           cd /tmp/marketplace
           git config user.name "hawkdeploy"
           git config user.email "hawkdeploy@stackhawk.com"
-          git add .claude-plugin/marketplace.json
+          git add -A
           if git diff --cached --quiet; then
-            echo "No changes — marketplace already pinned to ${{ needs.release.outputs.tag }}"
+            echo "No changes — marketplace already pinned to ${TAG}"
             exit 0
           fi
-          git commit -m "chore: pin agent-skills to ${{ needs.release.outputs.tag }}"
+          git commit -m "chore: pin agent-skills to ${TAG}"
           git push origin HEAD:main

--- a/scripts/generate-marketplace-catalogs.py
+++ b/scripts/generate-marketplace-catalogs.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Generate the agent-skills-marketplace catalogs from this repo's local catalogs.
+
+The marketplace repo (stackhawk/agent-skills-marketplace) holds curated,
+version-pinned catalogs that point BACK at this repo at a tagged release. The
+in-repo catalogs (.claude-plugin/marketplace.json, .codex-plugin/marketplace.json)
+use LOCAL-path plugin sources (./plugins/<name>) because the plugin dirs are
+co-located. A marketplace consumer, however, clones the marketplace repo — the
+plugins are NOT there — so each plugin source must be a REMOTE github source that
+points at this repo, at a subdirectory `path`, pinned to a tag + sha.
+
+The original hand-maintained marketplace catalogs omitted `path`, so every tool
+resolved this repo's ROOT and failed to find the plugins (which live under
+plugins/<name>). This generator is the single source of truth that prevents that:
+local-path source  ->  {source:github, repo, path:"plugins/<name>", ref, sha}
+
+The release publisher (release.yml `update-marketplace`) runs this against the
+release tag and pushes the output into the marketplace repo. It is also exercised
+by marketplace-install-verify.yml, which installs the generated catalogs through
+each tool to prove they resolve.
+
+Usage:
+  generate-marketplace-catalogs.py --tag v1.13.0 --sha <40-char-sha> --out-dir DIR
+      [--repo stackhawk/agent-skills] [--plugins hawkscan,stackhawk-api]
+
+  --plugins  Comma-separated allowlist controlling which plugins the marketplace
+             publishes (curation). Default mirrors the currently-published set.
+             Pass "all" to publish every plugin in the local catalog.
+"""
+import argparse
+import json
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Catalogs that use the github-remote-source model (path + ref + sha). Gemini
+# (gemini-extension.json, installed direct from the repo URL) and Copilot (reads
+# the .claude-plugin catalog) are intentionally not separate outputs here.
+CATALOG_SUBDIRS = (".claude-plugin", ".codex-plugin")
+
+# Default curation: the set currently published to the marketplace. Keeping this
+# explicit avoids silently promoting in-development plugins to the public catalog.
+DEFAULT_PLUGINS = ["hawkscan", "stackhawk-api"]
+
+
+def subpath_from_local_source(source):
+    """Local source -> 'plugins/<name>'. Accepts the claude string form
+    ('./plugins/x') and the codex object form ({'source':'local','path':'./plugins/x'})."""
+    raw = source.get("path", "") if isinstance(source, dict) else source
+    return raw.lstrip("./")
+
+
+def remote_source(repo, subpath, tag, sha):
+    return {"source": "github", "repo": repo, "path": subpath, "ref": tag, "sha": sha}
+
+
+def load_local_catalog(subdir):
+    with open(os.path.join(REPO_ROOT, subdir, "marketplace.json")) as f:
+        return json.load(f)
+
+
+def transform(catalog, repo, tag, sha, allow, descriptions):
+    """Rewrite each plugin's source to a pinned remote github source, filter to the
+    curation allowlist, and backfill description/homepage from the richest catalog."""
+    version = tag.lstrip("v")
+    out = dict(catalog)
+    plugins = []
+    for p in catalog.get("plugins", []):
+        if allow is not None and p["name"] not in allow:
+            continue
+        np = dict(p)
+        subpath = subpath_from_local_source(p["source"])
+        np["source"] = remote_source(repo, subpath, tag, sha)
+        np["version"] = version
+        # Backfill cosmetic fields (the codex catalog is sparser than claude's).
+        meta = descriptions.get(p["name"], {})
+        if not np.get("description") and meta.get("description"):
+            np["description"] = meta["description"]
+        if not np.get("homepage") and meta.get("homepage"):
+            np["homepage"] = meta["homepage"]
+        plugins.append(np)
+    out["plugins"] = plugins
+    return out, [pl["name"] for pl in plugins]
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Generate marketplace catalogs.")
+    ap.add_argument("--tag", required=True, help="Release tag, e.g. v1.13.0")
+    ap.add_argument("--sha", required=True, help="Commit sha the tag points at")
+    ap.add_argument("--out-dir", required=True, help="Output dir (marketplace repo root)")
+    ap.add_argument("--repo", default="stackhawk/agent-skills")
+    ap.add_argument("--plugins", default=",".join(DEFAULT_PLUGINS),
+                    help='Curation allowlist (comma-separated), or "all".')
+    args = ap.parse_args()
+
+    if args.plugins.strip().lower() == "all":
+        allow = None
+    else:
+        allow = [x.strip() for x in args.plugins.split(",") if x.strip()]
+
+    # Richest metadata source for backfill: the claude catalog (has description+homepage).
+    claude = load_local_catalog(".claude-plugin")
+    descriptions = {
+        p["name"]: {"description": p.get("description"), "homepage": p.get("homepage")}
+        for p in claude.get("plugins", [])
+    }
+
+    for subdir in CATALOG_SUBDIRS:
+        catalog = load_local_catalog(subdir)
+        out, names = transform(catalog, args.repo, args.tag, args.sha, allow, descriptions)
+        if allow is not None:
+            missing = [n for n in allow if n not in names]
+            if missing:
+                print(f"ERROR: {subdir}: requested plugins not in local catalog: {missing}",
+                      file=sys.stderr)
+                sys.exit(1)
+        out_subdir = os.path.join(args.out_dir, subdir)
+        os.makedirs(out_subdir, exist_ok=True)
+        out_path = os.path.join(out_subdir, "marketplace.json")
+        with open(out_path, "w") as f:
+            f.write(json.dumps(out, indent=2) + "\n")
+        print(f"wrote {subdir}/marketplace.json @ {args.tag} ({args.sha[:7]}): {names}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-marketplace-catalogs.py
+++ b/scripts/generate-marketplace-catalogs.py
@@ -37,7 +37,17 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Catalogs that use the github-remote-source model (path + ref + sha). Gemini
 # (gemini-extension.json, installed direct from the repo URL) and Copilot (reads
 # the .claude-plugin catalog) are intentionally not separate outputs here.
-CATALOG_SUBDIRS = (".claude-plugin", ".codex-plugin")
+# Per-flavor IO. `read` is the local in-repo catalog we pull plugin metadata from;
+# `writes` are the catalog paths to emit in the marketplace repo. Codex's CURRENT CLI
+# reads .agents/plugins/marketplace.json (verified against the real #1 codex
+# marketplace); the legacy .codex-plugin/marketplace.json is also emitted for older
+# CLIs. Claude Code reads .claude-plugin/marketplace.json and GitHub Copilot CLI reads
+# the same file — so no Copilot-specific output is needed.
+FLAVORS = (
+    {"flavor": "claude", "read": ".claude-plugin", "writes": [".claude-plugin/marketplace.json"]},
+    {"flavor": "codex", "read": ".codex-plugin",
+     "writes": [".agents/plugins/marketplace.json", ".codex-plugin/marketplace.json"]},
+)
 
 # Default curation: the set currently published to the marketplace. Keeping this
 # explicit avoids silently promoting in-development plugins to the public catalog.
@@ -126,22 +136,23 @@ def main():
         for p in claude.get("plugins", [])
     }
 
-    for subdir in CATALOG_SUBDIRS:
-        flavor = "codex" if subdir == ".codex-plugin" else "claude"
-        catalog = load_local_catalog(subdir)
+    for spec in FLAVORS:
+        flavor = spec["flavor"]
+        catalog = load_local_catalog(spec["read"])
         out, names = transform(flavor, catalog, args.repo, args.tag, args.sha, allow, descriptions)
         if allow is not None:
             missing = [n for n in allow if n not in names]
             if missing:
-                print(f"ERROR: {subdir}: requested plugins not in local catalog: {missing}",
+                print(f"ERROR: {spec['read']}: requested plugins not in local catalog: {missing}",
                       file=sys.stderr)
                 sys.exit(1)
-        out_subdir = os.path.join(args.out_dir, subdir)
-        os.makedirs(out_subdir, exist_ok=True)
-        out_path = os.path.join(out_subdir, "marketplace.json")
-        with open(out_path, "w") as f:
-            f.write(json.dumps(out, indent=2) + "\n")
-        print(f"wrote {subdir}/marketplace.json @ {args.tag} ({args.sha[:7]}): {names}")
+        out_json = json.dumps(out, indent=2) + "\n"
+        for rel in spec["writes"]:
+            out_path = os.path.join(args.out_dir, rel)
+            os.makedirs(os.path.dirname(out_path), exist_ok=True)
+            with open(out_path, "w") as f:
+                f.write(out_json)
+            print(f"wrote {rel} @ {args.tag} ({args.sha[:7]}): {names}")
 
 
 if __name__ == "__main__":

--- a/scripts/generate-marketplace-catalogs.py
+++ b/scripts/generate-marketplace-catalogs.py
@@ -51,7 +51,26 @@ def subpath_from_local_source(source):
     return raw.lstrip("./")
 
 
-def remote_source(repo, subpath, tag, sha):
+def remote_source(flavor, repo, subpath, tag, sha):
+    """Build the pinned remote plugin source. The two catalog flavors use DIFFERENT
+    remote-source schemas (verified by marketplace-install-verify.yml):
+
+      claude / copilot (.claude-plugin): {source:"github", repo, path:"plugins/x", ref, sha}
+        Claude Code resolves it; GitHub Copilot CLI reads the same .claude-plugin
+        catalog and resolves it too — no Copilot-specific manifest needed.
+
+      codex (.codex-plugin): {source:"git-subdir", url, path:"./plugins/x", ref, sha}
+        Codex does NOT understand the "github" source and silently finds no plugin;
+        it requires the "git-subdir" type with a full git URL and a `./`-relative path.
+    """
+    if flavor == "codex":
+        return {
+            "source": "git-subdir",
+            "url": f"https://github.com/{repo}.git",
+            "path": f"./{subpath}",
+            "ref": tag,
+            "sha": sha,
+        }
     return {"source": "github", "repo": repo, "path": subpath, "ref": tag, "sha": sha}
 
 
@@ -60,9 +79,10 @@ def load_local_catalog(subdir):
         return json.load(f)
 
 
-def transform(catalog, repo, tag, sha, allow, descriptions):
-    """Rewrite each plugin's source to a pinned remote github source, filter to the
-    curation allowlist, and backfill description/homepage from the richest catalog."""
+def transform(flavor, catalog, repo, tag, sha, allow, descriptions):
+    """Rewrite each plugin's source to a pinned remote source (schema per flavor),
+    filter to the curation allowlist, and backfill description/homepage from the
+    richest catalog."""
     version = tag.lstrip("v")
     out = dict(catalog)
     plugins = []
@@ -71,7 +91,7 @@ def transform(catalog, repo, tag, sha, allow, descriptions):
             continue
         np = dict(p)
         subpath = subpath_from_local_source(p["source"])
-        np["source"] = remote_source(repo, subpath, tag, sha)
+        np["source"] = remote_source(flavor, repo, subpath, tag, sha)
         np["version"] = version
         # Backfill cosmetic fields (the codex catalog is sparser than claude's).
         meta = descriptions.get(p["name"], {})
@@ -107,8 +127,9 @@ def main():
     }
 
     for subdir in CATALOG_SUBDIRS:
+        flavor = "codex" if subdir == ".codex-plugin" else "claude"
         catalog = load_local_catalog(subdir)
-        out, names = transform(catalog, args.repo, args.tag, args.sha, allow, descriptions)
+        out, names = transform(flavor, catalog, args.repo, args.tag, args.sha, allow, descriptions)
         if allow is not None:
             missing = [n for n in allow if n not in names]
             if missing:


### PR DESCRIPTION
Makes the `stackhawk/agent-skills-marketplace` catalogs actually installable and adds a way to prove it, after discovering they never worked end-to-end (missing `path`, stale v1.7.3, codex catalog at the wrong path).

## What's here
- **`scripts/generate-marketplace-catalogs.py`** — single source of truth. Translates this repo's local-path plugin sources into pinned remote sources with the correct **per-tool schema**:
  - `.claude-plugin/marketplace.json` → `{source:github, repo, path, ref, sha}` (Claude Code **and** GitHub Copilot read this)
  - `.agents/plugins/marketplace.json` → `{source:git-subdir, url, path, ref, sha}` (current Codex CLI; `.codex-plugin/` also emitted for legacy)
  - 2-plugin curation (`hawkscan`, `stackhawk-api`); `--plugins all` to widen.
- **`.github/workflows/marketplace-install-verify.yml`** — on-demand (`workflow_dispatch`) verifier. Installs from the catalog through each tool and asserts the plugin landed. Proven green: **claude-code, codex, copilot** (marketplace) and **agy** (direct install). Cursor = exploratory (copy-rules). agy job retains full discovery probes documenting that agy can't resolve a custom marketplace.
- **`release.yml`** — `update-marketplace` now runs the generator + `git add -A`, so every catalog is published on release (previously: claude-only rewrite that never added `path` and left codex orphaned).

## Verified
ENG-532 verify run (local mode = the exact bytes the publisher ships): all four CLI tools green.

## Note on release/version
Tooling/CI only — no skill content changed, so no version bump here. **Merging does not fix the live marketplace by itself**; that happens when the next `agent-skills` release runs the updated publisher (pushes corrected catalogs to the marketplace repo via the PAT).

Ticket: ENG-532

🤖 Generated with [Claude Code](https://claude.com/claude-code)