### PR TITLE
feat(evals): hawkscan app-discovery pulse eval

### DIFF
--- a/.github/workflows/hawkscan-discovery-eval.yml
+++ b/.github/workflows/hawkscan-discovery-eval.yml
@@ -1,0 +1,84 @@
+name: HawkScan Discovery Eval
+
+# Single-arm pulse of the hawkscan skill's app-discovery flow against real repos.
+# Manual, on-demand only (matches skill-evals.yml's deliberate workflow_dispatch design).
+# This is an eval (grade the current skill vs answer keys), NOT a blind A/B benchmark.
+on:
+  workflow_dispatch:
+    inputs:
+      model:
+        description: "Agent model"
+        required: false
+        default: "claude-sonnet-5"
+        type: string
+      no_judge:
+        description: "Deterministic process-checks only (skip the LLM judge)"
+        required: false
+        default: false
+        type: boolean
+      pass_threshold:
+        description: "Per-repo pass bar out of 12"
+        required: false
+        default: "9"
+        type: string
+
+# ---------------------------------------------------------------------------
+# Required secrets:
+#   ANTHROPIC_API_KEY      Anthropic API key for the headless agent + judge.
+#   RESEARCH_REPO_TOKEN    GitHub token with read access to the stackhawk-research
+#                          org (the eval clones its mirrored target apps). Falls back
+#                          to GITHUB_TOKEN, which will NOT have cross-org access.
+# ---------------------------------------------------------------------------
+permissions:
+  contents: read
+
+jobs:
+  discovery:
+    name: app-discovery pulse
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install claude CLI
+        run: curl -fsSL https://claude.ai/install.sh | bash
+
+      - name: Verify claude CLI
+        run: claude --version
+
+      - name: Configure access to stackhawk-research mirrors
+        env:
+          RESEARCH_REPO_TOKEN: ${{ secrets.RESEARCH_REPO_TOKEN }}
+          FALLBACK_TOKEN: ${{ github.token }}
+        run: |
+          TOKEN="${RESEARCH_REPO_TOKEN:-$FALLBACK_TOKEN}"
+          git config --global url."https://x-access-token:${TOKEN}@github.com/stackhawk-research/".insteadOf "https://github.com/stackhawk-research/"
+
+      - name: Run discovery eval
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          MODEL: ${{ inputs.model }}
+          NO_JUDGE: ${{ inputs.no_judge && '1' || '0' }}
+          PASS_THRESHOLD: ${{ inputs.pass_threshold }}
+        working-directory: evals/hawkscan-discovery
+        run: scripts/run.sh
+
+      - name: Publish report to run summary
+        if: always()
+        working-directory: evals/hawkscan-discovery
+        run: |
+          latest="$(ls -1d runs/* 2>/dev/null | tail -1)"
+          if [ -n "$latest" ] && [ -f "$latest/report.md" ]; then
+            cat "$latest/report.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No report produced (see logs)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload run artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: discovery-eval-run
+          path: evals/hawkscan-discovery/runs/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/evals/hawkscan-discovery/README.md
+++ b/evals/hawkscan-discovery/README.md
@@ -1,0 +1,69 @@
+# HawkScan App-Discovery Eval
+
+A **pulse** on the hawkscan skill's app-discovery flow (SKILL.md Step 1a): does the
+current skill guide an agent to correctly understand a real application before it
+configures a scan?
+
+This is an **eval, not a benchmark.** It runs a single arm — the current skill — against
+real repos and grades the result against a hand-built answer key, to keep a pulse on
+discovery health over time. (Blind A/B benchmarking of a skill *change*, OLD vs NEW, is a
+separate concern that lives in `stackhawk/agent-skills-devkit`.)
+
+## What it does
+
+For each repo in `apps.tsv`:
+
+1. Clone it fresh into an isolated working dir.
+2. Run the current hawkscan skill headless (`claude --print`) with **cwd = the cloned
+   app** and a **read-only guard** (`scripts/guard.py`) — the agent can read/grep/glob but
+   cannot write, start the app, scan, push, or reach a non-local host. cwd is the clone and
+   never the suite dir, so the agent can never see the answer keys.
+3. The agent ends with a `DISCOVERY:` block stating the six factors.
+4. Grade two ways (`scripts/grade.py`):
+   - **Deterministic process-checks** (no model): read docs first? explored manifests?
+     exploration breadth? emitted all answers? stayed read-only? fell back to the old
+     grep/node checklist? See `process-checks.json`.
+   - **Skill-blind judge** (`claude --print`, no skills/tools, blind to which skill version
+     produced the output) scores each factor against the answer key: correct/partial/wrong.
+5. `scripts/report.py` writes a per-repo scorecard and a pass/fail pulse.
+
+## The six graded factors
+
+Straight from `plugins/hawkscan/skills/hawkscan/references/app-discovery.md` (the four
+answers discovery must produce) plus **technology**:
+
+`technology`, `run_command`, `host` (+ running port), `api_style` (+ base path), `spa`, `auth`.
+
+## Repos
+
+Four real production apps mirrored in the `stackhawk-research` org, one per API style with
+no duplicate language/framework stack:
+
+| repo | API style | stack |
+|---|---|---|
+| firefly-iii | REST + OpenAPI | PHP / Laravel |
+| wikijs | GraphQL | JS (Node/Apollo) + Vue |
+| memos | gRPC | Go + React |
+| dawarich | server-rendered (also a REST/OpenAPI API) | Ruby / Rails |
+
+Answer keys with evidence citations live in `answer-keys/`.
+
+## Run it
+
+```bash
+export CLAUDE_CODE_OAUTH_TOKEN=...   # or ANTHROPIC_API_KEY
+cd evals/hawkscan-discovery
+scripts/run.sh --dry-run             # list cells, execute nothing
+scripts/run.sh                       # full run: clone, run, grade, report
+NO_JUDGE=1 scripts/run.sh            # deterministic process-checks only (no judge cost)
+```
+
+Output lands in `runs/<timestamp>/report.md`.
+
+## Notes / limitations
+
+- One run per repo; directional pulse, not a statistical result.
+- Answer keys are author-verified against pinned commits; re-verify when bumping a pin
+  (`apps.tsv`). Mirrors carry no release tags, so pins are commit SHAs.
+- Cloning `stackhawk-research` (a separate org) from CI needs a token with read access to
+  that org.

--- a/evals/hawkscan-discovery/answer-keys/dawarich.json
+++ b/evals/hawkscan-discovery/answer-keys/dawarich.json
@@ -1,0 +1,19 @@
+{
+  "app": "dawarich",
+  "api_type_slot": "Server-rendered web app (primary); also a documented REST API",
+  "technology": "Ruby 3.4.6, Rails 8.0. Server-rendered Hotwire (Turbo + Stimulus via importmap-rails); MapLibre JS for maps.",
+  "run_command": "`docker compose up` (upstream ships a compose stack with PostgreSQL + Redis + Sidekiq); or `bin/rails server` for local dev. Ruby 3.4.6.",
+  "host": "http://localhost:3000 (Rails/Puma default).",
+  "api_style": "Primary UX is a server-rendered HTML web app (Hotwire: Turbo + Stimulus). It ALSO exposes a REST API under /api (config/routes.rb `namespace :api`) documented by an OpenAPI/Swagger spec at swagger/v1/swagger.yaml.",
+  "spa": "no - server-rendered Rails with importmap + Stimulus + Turbo; no React/Vue SPA.",
+  "auth": "required. Devise session/form login (with devise-two-factor 2FA and OmniAuth OAuth). The REST API is authenticated with a per-user API key.",
+  "evidence": {
+    "technology": "Gemfile `gem 'rails', '~> 8.0'`; .ruby-version 3.4.6; Gemfile importmap-rails + stimulus-rails.",
+    "api_style": "config/routes.rb `namespace :api`; swagger/v1/swagger.yaml (OpenAPI spec); app/javascript is Hotwire-driven, not an SPA bundle.",
+    "host": "Rails/Puma default port 3000.",
+    "spa": "importmap-rails + stimulus-rails + Turbo; no React/Vue dependency.",
+    "auth": "Gemfile `gem 'devise'`, `gem 'devise-two-factor'`; app/models/concerns/omniauthable.rb; per-user API key for /api."
+  },
+  "verify_before_use": ["run_command: no compose file in mirror clone - confirm the upstream compose/run at eval authoring time"],
+  "notes": "Dual API surface: SSR primary (this is why it fills the server-rendered slot) plus a secondary REST+OpenAPI API. Overlaps firefly-iii on REST, but its PRIMARY style is SSR and its stack (Ruby/Rails) is distinct, so the 'one of each API type, no duplicate stack' constraint still holds."
+}

--- a/evals/hawkscan-discovery/answer-keys/firefly-iii.json
+++ b/evals/hawkscan-discovery/answer-keys/firefly-iii.json
@@ -1,0 +1,18 @@
+{
+  "app": "firefly-iii",
+  "api_type_slot": "REST + OpenAPI",
+  "technology": "PHP >= 8.5, Laravel 13. Server-rendered Blade UI with minor vanilla/Alpine JS.",
+  "run_command": "Official Docker image `fireflyiii/core` via docker compose against a database (MySQL/MariaDB/PostgreSQL/SQLite), served on container port 8080; or local dev with `php artisan serve` (Laravel dev server on 127.0.0.1:8000). A database is required.",
+  "host": "http://localhost:8080 (official Docker image) or http://127.0.0.1:8000 (php artisan serve). APP_URL defaults to http://localhost.",
+  "api_style": "REST. Base path /api/v1/. The OpenAPI/Swagger spec ships in the separate firefly-iii/api-docs repo, not served from this app.",
+  "spa": "no (server-rendered) - Blade templates; no React/Vue/Angular/Svelte SPA dependency in package.json.",
+  "auth": "required. Web UI = Laravel session via a server-rendered login/registration form. API (/api/v1/) = OAuth2 (laravel/passport) bearer tokens or Personal Access Tokens.",
+  "evidence": {
+    "technology": "composer.json: \"php\": \">=8.5\", \"laravel/framework\": \"^13\".",
+    "api_style": "routes/api.php Route::group over /api; changelog.md references /api/v1/users; no in-repo openapi/swagger file found.",
+    "host": ".env.example APP_URL=http://localhost (line 301).",
+    "spa": "package.json has no vue/react/@angular/core/svelte dependency.",
+    "auth": "composer.json: \"laravel/passport\": \"^13.0\"; server-rendered login routes."
+  },
+  "verify_before_use": ["run_command", "host: exact port depends on deploy method (8080 image vs 8000 artisan serve) - confirm at eval authoring time"]
+}

--- a/evals/hawkscan-discovery/answer-keys/memos.json
+++ b/evals/hawkscan-discovery/answer-keys/memos.json
@@ -1,0 +1,18 @@
+{
+  "app": "memos",
+  "api_type_slot": "gRPC",
+  "technology": "Go (go 1.26) backend; React 18 (TypeScript) front end in web/. usememos/memos.",
+  "run_command": "`docker run -p 5230:5230 neosmemo/memos:stable` with a mounted data volume (README); or build from source (Go server + web/ React build).",
+  "host": "http://localhost:5230 (README `-p 5230:5230` and \"Open http://localhost:5230\"; scripts/Dockerfile MEMOS_PORT=5230).",
+  "api_style": "gRPC. Service definitions in proto/api/v1/*.proto (memo_service, user_service, attachment_service, shortcut_service, instance_service...) under package memos.api.v1, exposed over HTTP via grpc-gateway. gRPC is the native API.",
+  "spa": "yes - React 18 client-rendered front end (web/).",
+  "auth": "required for user-scoped actions. Username/password sign-in issuing a session token; API access via bearer access tokens. Public/anonymous read is possible depending on a memo's visibility setting.",
+  "evidence": {
+    "technology": "go.mod module github.com/usememos/memos, go 1.26.2; web/package.json \"react\": \"^18.3.1\".",
+    "api_style": "proto/api/v1/memo_service.proto and sibling *.proto service files.",
+    "host": "README.md line 66 `-p 5230:5230`, line 71 http://localhost:5230; scripts/Dockerfile MEMOS_PORT=5230.",
+    "spa": "web/package.json react ^18.3.1, @types/react ^18.3.28.",
+    "auth": "access-token / session auth in server; visibility-based public read."
+  },
+  "verify_before_use": ["auth: confirm exact token header/session shape against the running instance at eval authoring time"]
+}

--- a/evals/hawkscan-discovery/answer-keys/wikijs.json
+++ b/evals/hawkscan-discovery/answer-keys/wikijs.json
@@ -1,0 +1,18 @@
+{
+  "app": "wikijs",
+  "api_type_slot": "GraphQL",
+  "technology": "Node.js (Express) backend with Apollo Server (GraphQL); Vue 2.6 + Vuetify single-page front end. Wiki.js v2.",
+  "run_command": "Docker image `ghcr.io/requarks/wiki:2` (aka requarks/wiki) against a database (PostgreSQL/MySQL/etc.); or `node server` after `yarn build`. Reads config.yml (copy config.sample.yml).",
+  "host": "http://localhost:3000 (config.sample.yml `port: 3000`).",
+  "api_style": "GraphQL. Endpoint /graphql served by apollo-server-express; schema in server/graph/schemas/*.graphql.",
+  "spa": "yes - Vue 2.6 + Vuetify client-rendered front end.",
+  "auth": "required for admin and most write actions. Local username/password login (form/session, JWT) plus many OAuth/SSO strategies (Auth0, Azure, GitHub, Google, GitLab, etc.). Public read access is configurable per-instance.",
+  "evidence": {
+    "technology": "package.json name \"wiki\" v2.0.0, \"apollo-server-express\": \"2.25.2\", \"vue\": \"2.6.14\", \"vuetify\": \"2.3.15\".",
+    "api_style": "server/graph/schemas/*.graphql (user, comment, asset, navigation, group...); apollo-server-express dependency.",
+    "host": "config.sample.yml `port: 3000` (\"Port the server should listen to\").",
+    "spa": "package.json vue + vuetify front end.",
+    "auth": "server/modules/authentication/ contains local plus auth0, azure, github, google, gitlab, ... strategies."
+  },
+  "verify_before_use": ["run_command: no Dockerfile in mirror clone - confirm image tag/run at eval authoring time"]
+}

--- a/evals/hawkscan-discovery/apps.tsv
+++ b/evals/hawkscan-discovery/apps.tsv
@@ -1,0 +1,4 @@
+firefly-iii	https://github.com/stackhawk-research/firefly-iii	75ee773c471f5776fd1c8cd4095af1d7013591f1
+wikijs	https://github.com/stackhawk-research/wikijs	ae3f7771a09aa5a081acde4239b97f85e7d312d1
+memos	https://github.com/stackhawk-research/memos	f61c743345169f88246c3f37bbdac08d90328866
+dawarich	https://github.com/stackhawk-research/dawarich	c958644a44b5177885e92921d8b135b5ab5be1a9

--- a/evals/hawkscan-discovery/process-checks.json
+++ b/evals/hawkscan-discovery/process-checks.json
@@ -1,0 +1,56 @@
+{
+  "skill": "hawkscan",
+  "phase": "app-discovery (Step 1a)",
+  "description": "Deterministic, model-free process checks for the hawkscan skill's app-discovery flow. Computed by scripts/grade.py from the run transcript. These are the objective backbone; the skill-blind judge (answer-key correctness) adds nuance on top.",
+  "checks": [
+    {
+      "id": "read_agent_docs",
+      "description": "Agent read the repo's own documentation (AGENTS.md, CLAUDE.md, README, CONTRIBUTING, docs/, .cursor/rules) at least once.",
+      "type": "tool_target_matches_docs",
+      "severity": "warning",
+      "rationale": "The docs-first discovery flow requires orienting from what the repo already says before exploring."
+    },
+    {
+      "id": "docs_before_conclusion",
+      "description": "Agent read a repo doc BEFORE emitting any discovery conclusion (DISCOVERY:/api_style:/host: http).",
+      "type": "ordering",
+      "severity": "warning",
+      "rationale": "Concluding before reading the docs is the exact failure mode the docs-first rewrite targets."
+    },
+    {
+      "id": "explored_manifests",
+      "description": "Agent inspected at least one build/manifest/API-defining file (go.mod, package.json, composer.json, Gemfile, .proto, .graphql, routes, Dockerfile, compose).",
+      "type": "tool_target_matches_manifest",
+      "severity": "warning",
+      "rationale": "Manifests are where technology/API-style are definitively determined."
+    },
+    {
+      "id": "exploration_breadth",
+      "description": "Count of distinct files/paths the agent read/grepped/globbed.",
+      "type": "count",
+      "severity": "informational",
+      "rationale": "A proxy for how thoroughly the agent investigated before concluding."
+    },
+    {
+      "id": "emitted_all_answers",
+      "description": "The final response contains all six discovery factors (technology, run_command, host, api_style, spa, auth).",
+      "type": "output_contains_all",
+      "severity": "blocking",
+      "rationale": "A discovery run that doesn't state all six answers can't be scored and hasn't finished the step."
+    },
+    {
+      "id": "stayed_read_only",
+      "description": "The read-only guard denied nothing (no writes, no app/container start, no scan, no remote push, no non-local egress).",
+      "type": "guard_clean",
+      "severity": "blocking",
+      "rationale": "Discovery is observational; any guard denial means the agent tried to act outside the discovery scope."
+    },
+    {
+      "id": "ran_legacy_command_menu",
+      "description": "Agent fell back to the old rigid grep/node command checklist (node -e react/vue probes, @PreAuthorize greps, -name openapi finds, launchSettings.json).",
+      "type": "command_matches_legacy",
+      "severity": "warning",
+      "rationale": "The docs-first rewrite replaced the rote command menu; falling back to it is a regression signal. Lower is better."
+    }
+  ]
+}

--- a/evals/hawkscan-discovery/prompt.txt
+++ b/evals/hawkscan-discovery/prompt.txt
@@ -1,0 +1,16 @@
+Using the hawkscan skill, perform the app-understanding/discovery step ONLY for the repository in the current working directory. Do NOT run any security scan, do NOT install anything, do NOT start the app or any container, and do NOT modify, create, or delete any files.
+
+Determine, by investigating the repository:
+1. The technology stack — the primary language and the application framework(s).
+2. How the app runs locally — the exact start command and the host/port it listens on.
+3. Its API style — REST (note an OpenAPI/Swagger spec if present), GraphQL, gRPC, or a plain server-rendered web app — and the API base path.
+4. Whether it is a single-page app (SPA) front end.
+5. Whether exercising its endpoints requires authentication, and what login shape it appears to use.
+
+End your response with a block that begins with the literal line "DISCOVERY:" followed by one line per answer:
+technology: ...
+run_command: ...
+host: ...
+api_style: ...
+spa: yes|no
+auth: required|not required — <shape>

--- a/evals/hawkscan-discovery/scripts/grade.py
+++ b/evals/hawkscan-discovery/scripts/grade.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Grade one discovery cell against its answer key.
+
+Two layers:
+  1. Deterministic process-checks read the run transcript and answer objective
+     questions with no model opinion (did it read the repo's own docs before
+     concluding? how many distinct files did it explore? did it fall back to the
+     old grep/node checklist? did it stay read-only?).
+  2. A skill-blind judge (fresh `claude --print`, no skills/tools) scores each of
+     the six discovery factors in the agent's DISCOVERY block against the
+     hand-built answer key: correct | partial | wrong.
+
+The deterministic layer is the backbone; the judge adds nuance. When they
+disagree, trust the objective signal.
+"""
+import argparse, json, os, re, subprocess, tempfile
+from pathlib import Path
+
+DOC_RE = re.compile(r"(AGENTS\.md|CLAUDE\.md|GEMINI\.md|copilot-instructions|\.cursor/|README|CONTRIBUTING|(^|/)docs/)", re.I)
+MANIFEST_RE = re.compile(r"(go\.mod|package\.json|pyproject\.toml|requirements\.txt|Gemfile|composer\.json|Dockerfile|docker-compose|compose\.ya?ml|pom\.xml|build\.gradle|\.csproj|\.proto|\.graphql|main\.(go|py|ts|js)|server\.(t|j)s|config/routes|routes?/)", re.I)
+LEGACY_RE = re.compile(r"(node -e .*(react|vue|spa)|@PreAuthorize|AddAuthentication\(|launchSettings\.json|-name \"openapi)", re.I)
+CONCLUSION_RE = re.compile(r"(DISCOVERY:|api_style:|host:\s*http)", re.I)
+
+# The six gradeable factors, in the order the answer key and DISCOVERY block use.
+FACTORS = ["technology", "run_command", "host", "api_style", "spa", "auth"]
+
+
+def _tool_target(name, ti):
+    if not isinstance(ti, dict):
+        return ""
+    if name in ("Read", "Edit", "Write"):
+        return str(ti.get("file_path", ""))
+    if name == "Glob":
+        return str(ti.get("pattern", ""))
+    if name == "Grep":
+        return f"{ti.get('pattern', '')} {ti.get('path', '')}"
+    if name == "Bash":
+        return str(ti.get("command", ""))
+    return json.dumps(ti)[:200]
+
+
+def parse_transcript(path):
+    tool_calls, events, texts = [], [], []
+    for line in Path(path).read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except Exception:
+            continue
+        t = ev.get("type")
+        if t == "assistant":
+            for block in ev.get("message", {}).get("content", []) or []:
+                if block.get("type") == "tool_use":
+                    tc = {"name": block.get("name", ""),
+                          "target": _tool_target(block.get("name", ""), block.get("input", {}))}
+                    tool_calls.append(tc)
+                    events.append({"kind": "tool", **tc})
+                elif block.get("type") == "text":
+                    txt = block.get("text", "")
+                    texts.append(txt)
+                    events.append({"kind": "text", "text": txt})
+        elif t == "result" and isinstance(ev.get("result"), str):
+            texts.append(ev["result"])
+    return {"tool_calls": tool_calls, "events": events, "final_text": texts[-1] if texts else ""}
+
+
+def process_checks(parsed):
+    calls = parsed["tool_calls"]
+    final = parsed["final_text"]
+    events = parsed.get("events", [])
+    read_targets = [c["target"] for c in calls if c["name"] in ("Read", "Grep", "Glob")]
+    all_cmds = " \n ".join(c["target"] for c in calls)
+    first_doc = first_concl = None
+    for i, e in enumerate(events):
+        if e.get("kind") == "tool" and e.get("name") in ("Read", "Grep", "Glob") and DOC_RE.search(e.get("target") or ""):
+            if first_doc is None:
+                first_doc = i
+        elif e.get("kind") == "text" and CONCLUSION_RE.search(e.get("text") or ""):
+            if first_concl is None:
+                first_concl = i
+    read_agent_docs = first_doc is not None
+    return {
+        "read_agent_docs": read_agent_docs,
+        "docs_before_conclusion": read_agent_docs and (first_concl is None or first_doc < first_concl),
+        "explored_manifests": any(MANIFEST_RE.search(t or "") for t in read_targets),
+        "exploration_breadth": len({t for t in read_targets if t}),
+        "emitted_all_answers": all(re.search(rf"\b{a}\b", final, re.I) for a in FACTORS),
+        "stayed_read_only": True,  # overwritten below if the guard denied anything
+        "ran_legacy_command_menu": bool(LEGACY_RE.search(all_cmds)),
+    }
+
+
+def build_judge_prompt(final_text, transcript_excerpt, answer_key):
+    return f"""You are grading how well an AI agent DISCOVERED an application before security scanning. You have no other tools or skills. You do not know which version of any skill produced this output; judge only the content.
+
+ANSWER KEY (the correct, hand-verified answers for this repo):
+{json.dumps(answer_key, indent=2)}
+
+The agent's final DISCOVERY output:
+---
+{final_text}
+---
+
+An excerpt of what the agent did (tool calls):
+---
+{transcript_excerpt}
+---
+
+Score each factor strictly against the answer key. "partial" = right idea but incomplete or slightly off; "wrong" = incorrect or missing. Return ONLY a JSON object:
+{{
+  "correctness": {{"technology":"correct|partial|wrong","run_command":"...","host":"...","api_style":"...","spa":"...","auth":"..."}},
+  "correctness_reasons": {{"technology":"...","run_command":"...","host":"...","api_style":"...","spa":"...","auth":"..."}},
+  "exploratory_score": 0,   // 0=blind guess, 3=thorough investigation to an educated conclusion
+  "jumped_to_conclusion": false,   // true if it fixated on one file / asserted host or API type with no corroboration / skipped the repo's docs
+  "jumped_to_conclusion_evidence": "..."
+}}"""
+
+
+def parse_judge_output(text):
+    text = text.strip()
+    m = re.search(r"```(?:json)?\s*(.*?)```", text, re.S)
+    if m:
+        text = m.group(1).strip()
+    try:
+        return json.loads(text)
+    except Exception:
+        pass
+    m = re.search(r"\{.*\}", text, re.S)
+    if m:
+        try:
+            return json.loads(m.group(0))
+        except Exception:
+            pass
+    raise ValueError("judge output not JSON: " + text[:200])
+
+
+def run_judge(prompt, model):
+    cfg = tempfile.mkdtemp(prefix="judge-cfg-")
+    Path(cfg, "settings.json").write_text('{"enableAllProjectMcpServers": false}')
+    env = dict(os.environ)
+    env["CLAUDE_CONFIG_DIR"] = cfg
+    for _ in range(3):
+        p = subprocess.run(["claude", "--print", "--output-format", "text", "--model", model],
+                           input=prompt, capture_output=True, text=True, env=env)
+        if p.returncode == 0 and p.stdout.strip():
+            try:
+                return parse_judge_output(p.stdout)
+            except ValueError:
+                continue
+    raise RuntimeError("judge failed after retries")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cell", required=True)
+    ap.add_argument("--app", required=True)
+    ap.add_argument("--answer-key", required=True)
+    ap.add_argument("--judge-model", default=os.environ.get("JUDGE_MODEL", "claude-opus-4-8"))
+    ap.add_argument("--no-judge", action="store_true")
+    a = ap.parse_args()
+    cell = Path(a.cell)
+    parsed = parse_transcript(cell / "transcript.jsonl")
+    checks = process_checks(parsed)
+    denies = cell / "guard-denies.txt"
+    if denies.exists() and denies.read_text().strip():
+        checks["stayed_read_only"] = False
+    (cell / "checks.json").write_text(json.dumps(checks, indent=2))
+    print(f"[checks] {a.app}: {json.dumps(checks)}")
+    if a.no_judge:
+        return
+    key = json.loads(Path(a.answer_key).read_text())
+    excerpt = "\n".join(f"{c['name']}: {c['target']}" for c in parsed["tool_calls"][:40])
+    grade = run_judge(build_judge_prompt(parsed["final_text"], excerpt, key), a.judge_model)
+    (cell / "grade.json").write_text(json.dumps(grade, indent=2))
+    n_correct = sum(1 for v in (grade.get("correctness") or {}).values() if v == "correct")
+    print(f"[judge] {a.app}: correct={n_correct}/{len(FACTORS)} explor={grade.get('exploratory_score')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/hawkscan-discovery/scripts/guard.py
+++ b/evals/hawkscan-discovery/scripts/guard.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""PreToolUse guardrail: discovery is read-only. Exit 0 allow, 2 deny (reason on stderr).
+
+Keeps the eval honest and safe: the agent may read/grep/glob the cloned app, but may
+not write files, start the app or a container, run a scan, push to a remote, or reach a
+non-local host. This is a cooperative safety net (heuristic), not an adversarial sandbox.
+"""
+import json, re, sys
+
+
+def deny(msg):
+    sys.stderr.write(f"Denied (read-only discovery): {msg}\n")
+    sys.exit(2)
+
+
+def main():
+    try:
+        event = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)  # unparseable -> don't block
+    tool = event.get("tool_name", "")
+    ti = event.get("tool_input", {}) or {}
+
+    if tool in ("Write", "Edit", "MultiEdit", "NotebookEdit"):
+        deny(f"{tool} would modify files")
+
+    if tool == "Bash":
+        cmd = ti.get("command", "") or ""
+        low = cmd.lower()
+        if "hawk scan" in low or re.search(r"\bhawk\s+scan\b", low):
+            deny("hawk scan is out of scope for discovery")
+        if re.search(r"\bgit\s+(commit|push)\b", low):
+            deny("git commit/push not allowed")
+        # don't start the app/server or a container runtime -- discovery reads, it doesn't run
+        if re.search(r"\b(docker|docker-compose|podman|nerdctl)\b", low) \
+           or re.search(r"\b(npm|pnpm|yarn)\s+(start|run\s+dev|run\s+serve|serve)\b", low) \
+           or re.search(r"\b(bootrun|runserver|uvicorn|gunicorn|hypercorn|nodemon|puma|rails\s+server)\b", low) \
+           or re.search(r"spring-boot:run|flask\s+run|mix\s+phx\.server|air\b|./gradlew\s+bootrun", low):
+            deny("starting the app/server/container is out of scope for read-only discovery")
+        if re.search(r"\b(rm|mv|tee|dd)\b|>\s*\S|>>", cmd):
+            deny("file mutation not allowed")
+        # network egress: block curl/wget/nc/ssh/etc. to non-local hosts
+        if re.search(r"\b(curl|wget|nc|ncat|telnet|ssh|scp)\b", low):
+            hosts = re.findall(r"https?://([^/\s:]+)|(?:^|\s)([a-z0-9.-]+\.[a-z]{2,})", low)
+            flat = [h for pair in hosts for h in pair if h]
+            local = {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
+            if any(h not in local for h in flat):
+                deny(f"network egress to non-local host: {flat}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/hawkscan-discovery/scripts/report.py
+++ b/evals/hawkscan-discovery/scripts/report.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Aggregate discovery-eval cells into a single-arm PULSE report.
+
+This is not a benchmark (no OLD-vs-NEW arms). It runs the current skill against
+each real repo and scores the discovery output against that repo's answer key, so
+we keep a pulse on whether the discovery flow is still healthy over time.
+
+Scoring: each of the six factors is worth correct=2, partial=1, wrong=0 (max 12).
+A repo PASSES when its score >= PASS_THRESHOLD (default 9/12) AND the must-hit
+factors (technology, api_style, host) are not wrong.
+"""
+import argparse, json, os, statistics
+from pathlib import Path
+
+FACTORS = ["technology", "run_command", "host", "api_style", "spa", "auth"]
+MUST_HIT = ["technology", "api_style", "host"]
+POINTS = {"correct": 2, "partial": 1, "wrong": 0}
+MAX_SCORE = 2 * len(FACTORS)
+PASS_THRESHOLD = int(os.environ.get("PASS_THRESHOLD", "9"))
+
+
+def _load(cell):
+    checks = json.loads((cell / "checks.json").read_text()) if (cell / "checks.json").exists() else {}
+    grade = json.loads((cell / "grade.json").read_text()) if (cell / "grade.json").exists() else {}
+    return {
+        **checks,
+        "exploratory_score": grade.get("exploratory_score"),
+        "jumped_to_conclusion": grade.get("jumped_to_conclusion"),
+        "correctness": grade.get("correctness", {}),
+    }
+
+
+def _score(row):
+    c = row.get("correctness") or {}
+    return sum(POINTS.get(c.get(f), 0) for f in FACTORS)
+
+
+def _passed(row):
+    c = row.get("correctness") or {}
+    if any(c.get(f) == "wrong" for f in MUST_HIT):
+        return False
+    return _score(row) >= PASS_THRESHOLD
+
+
+def aggregate(run_dir):
+    run_dir = Path(run_dir)
+    apps = {}
+    for cell in sorted((run_dir / "cells").glob("*")):
+        if not (cell / "checks.json").exists() and not (cell / "grade.json").exists():
+            continue
+        apps[cell.name] = _load(cell)
+    return apps
+
+
+def render_markdown(apps):
+    L = ["# HawkScan App-Discovery Eval - Pulse", "",
+         f"Current skill vs. hand-built answer keys. Pass = score >= {PASS_THRESHOLD}/{MAX_SCORE} "
+         "and no must-hit factor (technology/api_style/host) wrong.", "",
+         "## Per-repo scorecard", "",
+         "| repo | technology | run_command | host | api_style | spa | auth | score | docs-1st? | breadth | explor(0-3) | PASS |",
+         "|---|---|---|---|---|---|---|---|---|---|---|---|"]
+    n_pass = 0
+    for app, r in sorted(apps.items()):
+        c = r.get("correctness") or {}
+        cells = [c.get(f, "-") for f in FACTORS]
+        sc = _score(r)
+        ok = _passed(r)
+        n_pass += 1 if ok else 0
+        L.append(f"| {app} | " + " | ".join(cells) + f" | {sc}/{MAX_SCORE} | "
+                 f"{r.get('docs_before_conclusion')} | {r.get('exploration_breadth')} | "
+                 f"{r.get('exploratory_score')} | {'PASS' if ok else 'FAIL'} |")
+    total = len(apps)
+    L += ["", "## Pulse", "",
+          f"- **{n_pass}/{total} repos pass** the discovery bar.",
+          f"- Mean score: {round(statistics.mean(_score(r) for r in apps.values()), 2) if apps else 0}/{MAX_SCORE}.",
+          f"- Read docs before concluding: {sum(1 for r in apps.values() if r.get('docs_before_conclusion'))}/{total}.",
+          f"- Fell back to the old grep/node checklist: {sum(1 for r in apps.values() if r.get('ran_legacy_command_menu'))}/{total}.",
+          f"- Stayed read-only: {sum(1 for r in apps.values() if r.get('stayed_read_only'))}/{total}.",
+          "",
+          "Limitations: one run per repo; the answer keys are author-verified; the judge is an LLM "
+          "(the deterministic process-checks are the objective backbone)."]
+    return "\n".join(L), n_pass, len(apps)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--run", required=True)
+    a = ap.parse_args()
+    apps = aggregate(a.run)
+    md, n_pass, total = render_markdown(apps)
+    Path(a.run, "report.json").write_text(json.dumps(apps, indent=2))
+    Path(a.run, "report.md").write_text(md)
+    print(f"wrote {a.run}/report.md  ({n_pass}/{total} repos pass)")
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/hawkscan-discovery/scripts/run.sh
+++ b/evals/hawkscan-discovery/scripts/run.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# HawkScan app-discovery eval (single arm, pulse).
+# Clones each real repo, runs the CURRENT hawkscan skill headless against it with a
+# read-only guard, and grades the discovery output against the repo's answer key.
+#
+# Config via env:
+#   MODEL         agent model (default claude-sonnet-5)
+#   JUDGE_MODEL   skill-blind judge model (default claude-opus-4-8)
+#   PASS_THRESHOLD  per-repo pass bar out of 12 (default 9; consumed by report.py)
+#   NO_JUDGE=1    deterministic process-checks only (no ANTHROPIC_API_KEY needed)
+# Auth: export CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY for the headless runs.
+set -euo pipefail
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUITE_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SUITE_DIR/../.." && pwd)"
+SKILL_SRC="$REPO_ROOT/plugins/hawkscan/skills/hawkscan"
+MODEL="${MODEL:-claude-sonnet-5}"
+JUDGE_MODEL="${JUDGE_MODEL:-claude-opus-4-8}"
+NO_JUDGE_FLAG=""; [ "${NO_JUDGE:-0}" = "1" ] && NO_JUDGE_FLAG="--no-judge"
+DRY=0; [ "${1:-}" = "--dry-run" ] && DRY=1
+
+test -f "$SKILL_SRC/SKILL.md" || { echo "no hawkscan SKILL.md at $SKILL_SRC" >&2; exit 1; }
+
+TS="$(date +%Y%m%d-%H%M%S)"; RUN="$SUITE_DIR/runs/$TS"; mkdir -p "$RUN/cells"
+PROMPT="$(cat "$SUITE_DIR/prompt.txt")"
+echo "== discovery eval $TS  model=$MODEL judge=$JUDGE_MODEL dry=$DRY =="
+
+build_config_dir() {  # <cell_config_dir>
+  local cfg="$1"
+  rm -rf "$cfg"; mkdir -p "$cfg/skills" "$cfg/hooks"
+  cp -R "$SKILL_SRC" "$cfg/skills/hawkscan"
+  cp "$SCRIPTS_DIR/guard.py" "$cfg/hooks/guard.py"
+  python3 - "$MODEL" "$cfg" > "$cfg/settings.json" <<'PY'
+import json, sys
+model, cfg = sys.argv[1], sys.argv[2]
+json.dump({
+    "model": model,
+    "enableAllProjectMcpServers": False,
+    "hooks": {"PreToolUse": [{"matcher": "*", "hooks": [
+        {"type": "command", "command": f"python3 {cfg}/hooks/guard.py"}]}]},
+}, sys.stdout, indent=2)
+PY
+}
+
+while IFS=$'\t' read -r app url pin; do
+  [ -z "$app" ] && continue
+  cell="$RUN/cells/$app"; mkdir -p "$cell"
+  echo "-- cell $app ($url @ ${pin:0:12})"
+  [ "$DRY" = 1 ] && continue
+  git clone --depth 1 "$url" "$cell/workdir" >/dev/null 2>&1 \
+    || { echo "clone failed: $app" >&2; echo clone_failed > "$cell/error"; continue; }
+  if [ -n "$pin" ]; then
+    git -C "$cell/workdir" fetch --depth 1 origin "$pin" >/dev/null 2>&1 \
+      && git -C "$cell/workdir" checkout -q FETCH_HEAD 2>/dev/null || true
+  fi
+  build_config_dir "$cell/config" \
+    || { echo "config-build failed: $app" >&2; echo config_failed > "$cell/error"; continue; }
+  set +e
+  # cwd MUST be the cloned app -- never the suite dir, which holds the answer keys.
+  ( cd "$cell/workdir" && \
+    CLAUDE_CONFIG_DIR="$cell/config" BASH_DEFAULT_TIMEOUT_MS=2700000 BASH_MAX_TIMEOUT_MS=3600000 \
+    claude --print --verbose --output-format stream-json \
+      --permission-mode bypassPermissions --model "$MODEL" "$PROMPT" \
+      > "$cell/transcript.jsonl" 2> "$cell/agent.stderr" )
+  echo "$?" > "$cell/exit_code"
+  set -e
+  grep -i "Denied (read-only" "$cell/transcript.jsonl" "$cell/agent.stderr" \
+    > "$cell/guard-denies.txt" 2>/dev/null || true
+  python3 "$SCRIPTS_DIR/grade.py" --cell "$cell" --app "$app" \
+    --answer-key "$SUITE_DIR/answer-keys/$app.json" --judge-model "$JUDGE_MODEL" $NO_JUDGE_FLAG \
+    || echo "grade failed for $app" >&2
+done < "$SUITE_DIR/apps.tsv"
+
+[ "$DRY" = 1 ] && { echo "(dry run -- listed cells, executed nothing)"; exit 0; }
+python3 "$SCRIPTS_DIR/report.py" --run "$RUN"
+echo "DONE: $RUN/report.md"


### PR DESCRIPTION
## What

Adds a **single-arm pulse eval** for the hawkscan skill's app-discovery flow (SKILL.md Step 1a). It runs the **current** skill against four real production apps and grades the discovery output against **hand-built answer keys**, so we can watch for drift in how well the skill guides an agent to understand an app before configuring a scan.

**This is an eval, not a benchmark.** Blind OLD-vs-NEW A/B benchmarking of a skill *change* is a separate concern that lives in `stackhawk/agent-skills-devkit`. This suite just runs the current skill and scores it — a pulse, tracked over time.

## The four repos

One per API style, no duplicate language/framework stack, all mirrored in the `stackhawk-research` org (production apps, not intentionally-vulnerable training apps):

| repo | API style | stack |
|---|---|---|
| firefly-iii | REST + OpenAPI | PHP / Laravel |
| wikijs | GraphQL | JS (Node/Apollo) + Vue |
| memos | gRPC | Go + React |
| dawarich | server-rendered (also a REST/OpenAPI API) | Ruby / Rails |

## How it grades

For each repo: clone fresh → run the skill headless with **cwd = the clone** and a **read-only guard** (can't write, start the app, scan, push, or reach a non-local host; can never see the answer keys) → the agent ends with a `DISCOVERY:` block → grade two ways:

- **Deterministic process-checks** (no model): read the repo's docs before concluding? explored manifests? exploration breadth? stayed read-only? fell back to the old grep/node checklist? — the objective backbone.
- **Skill-blind judge** (`claude --print`, no skills/tools, blind to skill version): scores each factor against the answer key — correct/partial/wrong.

**Graded factors** (from `references/app-discovery.md` + technology): `technology`, `run_command`, `host`+port, `api_style`+base path, `spa`, `auth`.

## Files

- `evals/hawkscan-discovery/` — `apps.tsv`, `prompt.txt`, `answer-keys/*.json` (with evidence citations), `scripts/{run.sh,grade.py,report.py,guard.py}`, `process-checks.json`, `README.md`.
- `.github/workflows/hawkscan-discovery-eval.yml` — `workflow_dispatch`, mirrors `skill-evals.yml`'s on-demand design.

## Safety / validation

- **No existing eval files touched** — purely additive. `uv run validate` still passes all five existing suites.
- Grading pipeline verified end-to-end locally with a synthetic transcript (process-checks + scorecard render correctly); `--dry-run` lists cells without executing.

## Reviewer notes / follow-ups

- **Answer keys are author-verified** against pinned commits; re-verify when bumping a pin. The `stackhawk-research` mirrors carry no release tags, so pins are commit SHAs.
- **CI needs a `RESEARCH_REPO_TOKEN` secret** with read access to `stackhawk-research` (a separate org) to clone the target apps; falls back to `GITHUB_TOKEN` (which won't have cross-org access). `ANTHROPIC_API_KEY` drives the agent + judge.
- `dawarich` is dual-surface (server-rendered primary + a documented REST API); its answer key states both honestly rather than forcing a clean bucket.

Related: ENG-639.

🤖 Generated with [Claude Code](https://claude.com/claude-code)