### PR TITLE
fix(evals): non-claude adapters accept target_repo (fixes PLUMBING FAILURE)

### DIFF
--- a/evals/harnesses/agy/adapter.py
+++ b/evals/harnesses/agy/adapter.py
@@ -148,7 +148,16 @@ class AgyAdapter:
         max_budget: float,
         bare: bool,
         full_auto: bool,
+        target_repo=None,
     ) -> ParsedRun:
+        if target_repo is not None:
+            # Discovery (target_repo) cells clone a real repo and explore it for
+            # real; that path is wired only for the claude-code harness (only its
+            # CI job mints RESEARCH_REPO_TOKEN to read the stackhawk-research repos).
+            # Fail the cell cleanly here rather than run the agent against an empty
+            # cwd -- mirrors claude-code's own "clone failed" fallback, so the rest
+            # of the suite still runs. (agy is text-only, so it cannot explore anyway.)
+            return ParsedRun(error="discovery (target_repo) cells run only on the claude-code harness")
         # Skills are installed globally via `agy plugin install` in CI;
         # load_skill toggling is a no-op here.
         tmpdir = tempfile.mkdtemp(prefix=f"hawkeval_{run_id}_")

--- a/evals/harnesses/codex/adapter.py
+++ b/evals/harnesses/codex/adapter.py
@@ -153,7 +153,15 @@ class CodexAdapter:
                               loose_hit=loose)
 
     def launch(self, prompt, skill, run_id, plugin_dirs, *, model, load_skill,
-               max_budget, bare, full_auto) -> ParsedRun:
+               max_budget, bare, full_auto, target_repo=None) -> ParsedRun:
+        if target_repo is not None:
+            # Discovery (target_repo) cells clone a real repo and explore it for
+            # real; that path is wired only for the claude-code harness (only its
+            # CI job mints RESEARCH_REPO_TOKEN to read the stackhawk-research repos).
+            # Fail the cell cleanly here rather than run the agent against an empty
+            # cwd -- mirrors claude-code's own "clone failed" fallback, so the rest
+            # of the suite still runs.
+            return ParsedRun(error="discovery (target_repo) cells run only on the claude-code harness")
         tmpdir = tempfile.mkdtemp(prefix=f"hawkeval_{run_id}_")
         try:
             # In CI the bubblewrap sandbox can't initialize (Ubuntu 24.04 blocks

--- a/evals/harnesses/cursor/adapter.py
+++ b/evals/harnesses/cursor/adapter.py
@@ -203,7 +203,15 @@ class CursorAdapter:
                               loose_hit=loose)
 
     def launch(self, prompt, skill, run_id, plugin_dirs, *, model, load_skill,
-               max_budget, bare, full_auto) -> ParsedRun:
+               max_budget, bare, full_auto, target_repo=None) -> ParsedRun:
+        if target_repo is not None:
+            # Discovery (target_repo) cells clone a real repo and explore it for
+            # real; that path is wired only for the claude-code harness (only its
+            # CI job mints RESEARCH_REPO_TOKEN to read the stackhawk-research repos).
+            # Fail the cell cleanly here rather than run the agent against an empty
+            # cwd -- mirrors claude-code's own "clone failed" fallback, so the rest
+            # of the suite still runs.
+            return ParsedRun(error="discovery (target_repo) cells run only on the claude-code harness")
         tmpdir = tempfile.mkdtemp(prefix=f"hawkeval_{run_id}_")
         try:
             # With/without-skill switch: only install the cursor rules when the

--- a/tests/lib/test_adapter_target_repo.py
+++ b/tests/lib/test_adapter_target_repo.py
@@ -111,5 +111,43 @@ class AdapterTargetRepo(unittest.TestCase):
                       "scan cells keep the passed-in runtime budget cap")
 
 
+class NonClaudeAdapterTargetRepo(unittest.TestCase):
+    """The non-claude adapters must ACCEPT the target_repo kwarg (the CLI passes
+    it on every launch) and short-circuit discovery cells cleanly. Regression for
+    the PLUMBING FAILURE where cli.py passed target_repo=... to launch() but only
+    claude-code's signature accepted it, so every cell on codex/cursor/agy raised
+    TypeError and 0/N ran cleanly."""
+
+    ADAPTERS = ("codex", "cursor", "agy")
+
+    def test_launch_accepts_target_repo_kwarg(self):
+        # No target_repo: launch() must accept the keyword without raising a
+        # TypeError just for its presence in the signature. We don't run the
+        # agent here; a raised TypeError would name the bad kwarg.
+        import inspect
+        for name in self.ADAPTERS:
+            adapter = get_adapter(name)
+            params = inspect.signature(adapter.launch).parameters
+            self.assertIn("target_repo", params,
+                          f"{name} adapter.launch must accept target_repo")
+
+    def test_discovery_cell_short_circuits_without_shelling_out(self):
+        tr = TargetRepo(url="https://github.com/stackhawk-research/x.git", pin="deadbeef")
+        for name in self.ADAPTERS:
+            adapter = get_adapter(name)
+            calls = []
+            with mock.patch("subprocess.run",
+                            lambda cmd, *a, **k: calls.append(cmd)):
+                run = adapter.launch("discover", "hawkscan", "x", ["/plug"],
+                                     model=None, load_skill=True, max_budget=0.2,
+                                     bare=False, full_auto=False, target_repo=tr)
+            self.assertIsNotNone(run.error,
+                                 f"{name}: discovery cell should return an error, not run")
+            self.assertIn("claude-code", run.error,
+                          f"{name}: error should explain discovery is claude-code only")
+            self.assertEqual(calls, [],
+                             f"{name}: must not shell out for an unsupported discovery cell")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Every `codex`, `cursor`, and `agy` job in the **Skill Evals** workflow dies with:

```
PLUMBING FAILURE: eval ran 0/N prompts cleanly for <agent>/<skill>.
Causes: ['harness exception: TypeError: <Agent>Adapter.launch() got an unexpected keyword argument 'target_repo'']
```

(Observed in run [29283965122](https://github.com/stackhawk/agent-skills/actions/runs/29283965122). Every `claude-code` job was green; every codex/cursor/agy job was red.)

## Root cause

The `target_repo` (app-discovery) feature added `adapter.launch(..., target_repo=p.target_repo)` in `evals/cli.py` — passed on **every** cell — plus the `harness.py` Protocol, `models.py`, and the **claude-code** adapter's `launch()`. The `codex`, `cursor`, and `agy` adapters were never updated, so every cell raised `TypeError` before the agent ran → 0/N cells ran cleanly → the job exits 1 (`PLUMBING FAILURE`).

This is a **mainline** bug — the eval harness is byte-identical on `main` and on the feature branch where it surfaced.

## Fix

- Add `target_repo=None` to the `launch()` signature of the codex, cursor, and agy adapters.
- Discovery cells clone `stackhawk-research` repos and explore for real; that path is wired for **claude-code only** (only its CI job mints `RESEARCH_REPO_TOKEN`). When `target_repo` is set, the other adapters return a clean `ParsedRun(error=...)` — the faithful equivalent of claude-code's own clone-failed fallback, so the discovery cell fails as *data* while the rest of the suite runs cleanly (no plumbing failure).
- Regression test asserting each non-claude adapter accepts `target_repo` and short-circuits without shelling out. **It fails against the pre-fix adapters** (reproduces the exact `TypeError`).

## Verification

Dispatched Skill Evals on the fix branch (CI holds the secrets):

| Agent | Result |
|---|---|
| **cursor** | ✅ all 5 skills GREEN (was 100% red). hawkscan: 20 non-discovery cells ran cleanly; the 4 discovery cells short-circuited with the claude-code-only note, exactly as designed. |
| **agy** | Advanced past the `TypeError`; stays red on a **pre-existing, unrelated** blocker also on `main`: `no headless auth (upstream antigravity-cli#78) — not runnable in CI`. Out of scope for this fix. |
| **codex** | Not dispatched — byte-identical additive change; cursor proves the pattern end-to-end. |

`uv run pytest` (190 passed) and `uv run validate` pass locally.